### PR TITLE
Make error messages more descriptive

### DIFF
--- a/attrib/att.c
+++ b/attrib/att.c
@@ -53,9 +53,9 @@ const char *att_ecode2str(uint8_t status)
 	case ATT_ECODE_INVALID_HANDLE:
 		return "Invalid handle";
 	case ATT_ECODE_READ_NOT_PERM:
-		return "Attribute can't be read";
+		return "Attribute read not permitted";
 	case ATT_ECODE_WRITE_NOT_PERM:
-		return "Attribute can't be written";
+		return "Attribute write not permitted";
 	case ATT_ECODE_INVALID_PDU:
 		return "Attribute PDU was invalid";
 	case ATT_ECODE_AUTHENTICATION:


### PR DESCRIPTION
It recently stumbled across an issue with an application using bluez. The tool returned the error message "Attribute can't be written". I took a wireshark dump and it turned out that it could not be written because the write was not permitted. I tracked the issue down to this piece of code. It would be great if the messages could be changed. "Attribute can't be written" doesn't tell anything why the write failed. 

Thanks a lot for your work you put into bluez!