### PR TITLE
testtools - fix: 'SIOCGSTAMP' undeclared error

### DIFF
--- a/tools/l2test.c
+++ b/tools/l2test.c
@@ -29,6 +29,9 @@
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#if defined(__linux__)
+#include <linux/sockios.h>
+#endif
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"

--- a/tools/rctest.c
+++ b/tools/rctest.c
@@ -27,6 +27,9 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#if defined(__linux__)
+#include <linux/sockios.h>
+#endif
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"


### PR DESCRIPTION
- below errors fixed for linux

| ../bluez5/tools/rctest.c: error: 'SIOCGSTAMP' undeclared
|     if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
|                   ^~~~~~~~~~
| ../bluez/tools/l2test.c: error: 'SIOCGSTAMP' undeclared
|     if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
|                   ^~~~~~~~~~

Signed-off-by: Moorthy Baskar <moorthy.bs@ltts.com>