### PR TITLE
avdtp: Correct possible dereferencing of null pointer in avdtp_abort

### DIFF
--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -3643,7 +3643,7 @@ int avdtp_abort(struct avdtp *session, struct avdtp_stream *stream)
 	int ret;
 
 	if (!stream){
-        if (!session->discover) {
+        if (session->discover) {
             /* Don't call cb since it being aborted */
             session->discover->cb = NULL;
             finalize_discovery(session, ECANCELED);

--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -3642,10 +3642,12 @@ int avdtp_abort(struct avdtp *session, struct avdtp_stream *stream)
 	struct seid_req req;
 	int ret;
 
-	if (!stream && session->discover) {
-		/* Don't call cb since it being aborted */
-		session->discover->cb = NULL;
-		finalize_discovery(session, ECANCELED);
+	if (!stream){
+        if (!session->discover) {
+            /* Don't call cb since it being aborted */
+            session->discover->cb = NULL;
+            finalize_discovery(session, ECANCELED);
+        }
 		return -EALREADY;
 	}
 


### PR DESCRIPTION
When stream is null and session->discover is not (this actually happened), stream will be dereferenced further down in the code.