### PR TITLE
sixaxis: Fix Bluetooth PS3 clone joypad being named like the original 

### DIFF
--- a/plugins/sixaxis.c
+++ b/plugins/sixaxis.c
@@ -387,6 +387,7 @@ get_pairing_type_for_device(struct udev_device *udevice, uint16_t *bus,
 						char **sysfs_path)
 {
 	struct udev_device *hid_parent;
+	const char *hid_name;
 	const char *hid_id;
 	const struct cable_pairing *cp;
 	uint16_t vid, pid;
@@ -401,7 +402,9 @@ get_pairing_type_for_device(struct udev_device *udevice, uint16_t *bus,
 	if (!hid_id || sscanf(hid_id, "%hx:%hx:%hx", bus, &vid, &pid) != 3)
 		return NULL;
 
-	cp = get_pairing(vid, pid);
+	hid_name = udev_device_get_property_value(hid_parent, "HID_NAME");
+
+	cp = get_pairing(vid, pid, hid_name);
 	*sysfs_path = g_strdup(udev_device_get_syspath(udevice));
 
 	return cp;

--- a/profiles/input/server.c
+++ b/profiles/input/server.c
@@ -120,7 +120,7 @@ static bool dev_is_sixaxis(const bdaddr_t *src, const bdaddr_t *dst)
 	vid = btd_device_get_vendor(device);
 	pid = btd_device_get_product(device);
 
-	cp = get_pairing(vid, pid);
+	cp = get_pairing(vid, pid, NULL);
 	if (cp && (cp->type == CABLE_PAIRING_SIXAXIS ||
 					cp->type == CABLE_PAIRING_DS4))
 		return true;

--- a/profiles/input/sixaxis.h
+++ b/profiles/input/sixaxis.h
@@ -29,11 +29,19 @@ struct cable_pairing {
 };
 
 static inline const struct cable_pairing *
-get_pairing(uint16_t vid, uint16_t pid)
+get_pairing(uint16_t vid, uint16_t pid, const char *name)
 {
 	static const struct cable_pairing devices[] = {
 		{
 			.name = "Sony PLAYSTATION(R)3 Controller",
+			.source = 0x0002,
+			.vid = 0x054c,
+			.pid = 0x0268,
+			.version = 0x0000,
+			.type = CABLE_PAIRING_SIXAXIS,
+		},
+		{
+			.name = "SHANWAN PS3 GamePad",
 			.source = 0x0002,
 			.vid = 0x054c,
 			.pid = 0x0268,
@@ -71,6 +79,9 @@ get_pairing(uint16_t vid, uint16_t pid)
 		if (devices[i].vid != vid)
 			continue;
 		if (devices[i].pid != pid)
+			continue;
+
+		if (name && strcmp(name, devices[i].name))
 			continue;
 
 		return &devices[i];


### PR DESCRIPTION
This is required to enable quirks for Shanwan clones in hid-sony
driver.