### PR TITLE
tools/bdaddr: Support Cypress Semiconductor reported in Raspberry Pi4

### DIFF
--- a/tools/bdaddr.c
+++ b/tools/bdaddr.c
@@ -303,6 +303,7 @@ static struct {
 	{ 48,		st_write_bd_addr,	generic_reset_device	},
 	{ 57,		ericsson_write_bd_addr,	generic_reset_device	},
 	{ 72,		mrvl_write_bd_addr,	generic_reset_device	},
+	{ 305,		bcm_write_bd_addr,	generic_reset_device	},
 	{ 65535,	NULL,			NULL			},
 };
 


### PR DESCRIPTION
This patch add bdaddr support for Raspberry Pi4 for Manufacturer id 305

Manufacturer:   Cypress Semiconductor (305)