### PR TITLE
Include limits.h for PATH_MAX

### DIFF
--- a/tools/mesh-cfgtest.c
+++ b/tools/mesh-cfgtest.c
@@ -22,6 +22,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <signal.h>
+#include <limits.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
PATH_MAX is defined in limits.h so include it explicitly.

This fixes the following compile error on musl libc (Alpine Linux):
```
tools/mesh-cfgtest.c: In function 'setup_test_dir':
tools/mesh-cfgtest.c:1347:11: error: 'PATH_MAX' undeclared (first use in this function)
 1347 |  char buf[PATH_MAX];
      |           ^~~~~~~~
```