### PR TITLE
    I want to explain it as　“Master Or Slave”, because this is explai…

### DIFF
--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -4143,7 +4143,7 @@ static void create_conn_cmd(const void *data, uint8_t size)
 		str = "Stay master";
 		break;
 	case 0x01:
-		str = "Allow slave";
+		str = "Master Or Slave";
 		break;
 	default:
 		str = "Reserved";


### PR DESCRIPTION
…ned in the Core_v5.2

    8.6.5 Role switch
    There are several occasions when a role switch is used:
    • A role switch is necessary in order to make a paging device a slave when
    joining an existing piconet, since by definition the paging device is initially
    master of a piconet involving the pager (master) and the paged (slave)
    device.
    • A role switch is necessary in order for a slave in an existing piconet to set up
    a new piconet with itself as master and the original piconet master as slave.
    If the original piconet had more than one slave, then this implies a double
    role for the original piconet master; it becomes a slave