### PR TITLE
fix for fake PS3 controller

### DIFF
--- a/profiles/input/sixaxis.h
+++ b/profiles/input/sixaxis.h
@@ -80,7 +80,9 @@ get_pairing(uint16_t vid, uint16_t pid, const char *name)
 			continue;
 		if (devices[i].pid != pid)
 			continue;
-
+		// treat all fake PS3 controller as SHANWAN
+		if (strcmp(devices[i].name, "SHANWAN PS3 GamePad") == 0)
+			return &devices[i];
 		if (name && strcmp(name, devices[i].name))
 			continue;
 


### PR DESCRIPTION
simplely treat all fake PS3 controller as SHANWAN.
some controllers may work, at least mine is work well now.