### PR TITLE
fix error handler segfault when key file is missing

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -5003,7 +5003,7 @@ static void update_bredr_services(struct browse_req *req, sdp_list_t *recs)
 	if (!g_key_file_load_from_file(sdp_key_file, sdp_file, 0, &gerr)) {
 		error("Unable to load key file from %s: (%s)", sdp_file,
 								gerr->message);
-		g_error_free(gerr);
+		g_clear_error(&gerr);
 	}
 
 	snprintf(att_file, PATH_MAX, STORAGEDIR "/%s/%s/attributes", srcaddr,
@@ -5013,7 +5013,7 @@ static void update_bredr_services(struct browse_req *req, sdp_list_t *recs)
 	if (!g_key_file_load_from_file(att_key_file, att_file, 0, &gerr)) {
 		error("Unable to load key file from %s: (%s)", att_file,
 								gerr->message);
-		g_error_free(gerr);
+		g_clear_error(&gerr);
 	}
 
 	for (seq = recs; seq; seq = seq->next) {
@@ -5073,7 +5073,7 @@ next:
 								&gerr)) {
 				error("Unable set contents for %s: (%s)",
 						sdp_file, gerr->message);
-				g_error_free(gerr);
+				g_clear_error(&gerr);
 			}
 		}
 
@@ -5089,7 +5089,7 @@ next:
 								&gerr)) {
 				error("Unable set contents for %s: (%s)",
 						att_file, gerr->message);
-				g_error_free(gerr);
+				g_clear_error(&gerr);
 			}
 		}
 


### PR DESCRIPTION
When a missing key file error is handled by update_bredr_services, g_error_free was used to clear the error. However, this left the gerr local pointer as non-NULL. The pointer was then re-used in g_file_set_contents, which immediately returns, because it expects its error pointer parameter to be NULL. The next error handler then handles the original (g_error_free'd) error pointer again, incorrectly accessing gerr->message and calling g_error_free on the same pointer a second time, resulting in a segfault.

This change replaces g_error_free with g_clear_error, to ensure that the error pointer is set to NULL once it has been handled. Tested this fixes the issue for my configuration of CSR USB dongle 0a12:001 with Mi Smart Band 4.