### PR TITLE
fix writing out of bounds array

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -3831,7 +3831,7 @@ static int load_chrc(char *handle, char *value,
 	uint16_t properties, value_handle, handle_int;
 	char uuid_str[MAX_LEN_UUID_STR];
 	struct gatt_db_attribute *att;
-	char val_str[32];
+	char val_str[33];
 	uint8_t val[16];
 	size_t val_len;
 	bt_uuid_t uuid;


### PR DESCRIPTION
In line 3843, a zero byte is written beyond the array `char val_str[32];` boundary.
```cpp
if (sscanf(value, GATT_CHARAC_UUID_STR ":%04hx:%02hx:%32s:%s",
```

since the order of location of local variables on the stack is not defined, the situation of information access on the stack is possible.
 
For example, when overwriting and then filling only the first element of the array `uint8_t val[16];`, with data output through

```cpp
	DBG("loading characteristic handle: 0x%04x, value handle: 0x%04x,"
				" properties 0x%04x value: %s uuid: %s",
				handle_int, value_handle, properties,
				val_len ? val_str : "", uuid_str);
```

POC
```cpp
#include <stdio.h>
#include <stddef.h>
#include <locale.h>

typedef unsigned char uint8_t;
typedef  unsigned short uint16_t;
typedef unsigned long size_t;
typedef long ssize_t;

#define GATT_CHARAC_UUID_STR "2803"
#define MAX_LEN_UUID_STR 37

char  value[] = "2803:aaaa:bb:31x45678901234567890123456789012:strtmp";


ssize_t str2val(const char *str, uint8_t *val, size_t len)
{
	const char *pos = str;
	size_t i;

	for (i = 0; i < len; i++) {
		if (sscanf(pos, "%2hhx", &val[i]) != 1)
			break;
		pos += 2;
	}

	return i;
}


int main(void)
{
    uint16_t properties, value_handle, handle_int;
	char uuid_str[MAX_LEN_UUID_STR];
	char val_str[32];
	uint8_t val[]="HIDE PRIVATE STACK SECURITY DATA";
	size_t val_len;



    if(sscanf(value, GATT_CHARAC_UUID_STR ":%04hx:%02hx:%32s:%s",&value_handle, &properties, val_str, uuid_str) == 4 )
        val_len = str2val(val_str, val, sizeof(val));

    printf("loading characteristic handle: 0x%04x, value handle: 0x%04x,"
				" properties 0x%04x value: %s uuid: %s",
				handle_int, value_handle, properties,
				val_len ? val_str : "", uuid_str);

}
```

loading characteristic handle: 0x0000, value handle: 0xaaaa, properties 0x00bb value: 31x456789012345678901234567890121I`DE PRIVATE STACK SECURITY DATA` uuid: strtmp


https://coliru.stacked-crooked.com/view?id=40c23adc766bbd98
