### PR TITLE
avdtp: Free session->discover when send_request returns error

### DIFF
--- a/profiles/audio/avdtp.c
+++ b/profiles/audio/avdtp.c
@@ -3429,6 +3429,11 @@ int avdtp_discover(struct avdtp *session, avdtp_discover_cb_t cb,
 	if (err == 0) {
 		session->discover->cb = cb;
 		session->discover->user_data = user_data;
+	} else {
+		if (session->discover) {
+			g_free(session->discover);
+			session->discover = NULL;
+		}
 	}
 
 	return err;


### PR DESCRIPTION
When send_request returns an error, session->discover should
be released here, so that the next time the program enters
avdtp_discover, the -EBUSY error will not be returned.