### PR TITLE
ExcludeAdapters setting for input.conf

### DIFF
--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -82,6 +82,9 @@ struct input_device {
 static int idle_timeout = 0;
 static bool uhid_enabled = false;
 static bool classic_bonded_only = false;
+static char* exclude_adapter_address;
+static char** exclude_adapters;
+static gsize num_exclude_adapters;
 
 void input_set_idle_timeout(int timeout)
 {
@@ -101,6 +104,26 @@ void input_set_classic_bonded_only(bool state)
 bool input_get_classic_bonded_only(void)
 {
 	return classic_bonded_only;
+}
+
+char** input_get_exclude_adapters(void)
+{
+	return exclude_adapters;
+}
+
+void input_set_exclude_adapters(char** adapters)
+{
+    exclude_adapters = adapters;
+}
+
+gsize input_get_num_exclude_adapters(void)
+{
+	return num_exclude_adapters;
+}
+
+void input_set_num_exclude_adapters(gsize num)
+{
+    num_exclude_adapters = num;
 }
 
 static void input_device_enter_reconnect_mode(struct input_device *idev);

--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -82,7 +82,6 @@ struct input_device {
 static int idle_timeout = 0;
 static bool uhid_enabled = false;
 static bool classic_bonded_only = false;
-static char* exclude_adapter_address;
 static char** exclude_adapters;
 static gsize num_exclude_adapters;
 

--- a/profiles/input/device.h
+++ b/profiles/input/device.h
@@ -19,6 +19,10 @@ void input_enable_userspace_hid(bool state);
 void input_set_classic_bonded_only(bool state);
 bool input_get_classic_bonded_only(void);
 void input_set_auto_sec(bool state);
+char** input_get_exclude_adapters(void);
+void input_set_exclude_adapters(char** address);
+gsize input_get_num_exclude_adapters(void);
+void input_set_num_exclude_adapters(gsize address);
 
 int input_device_register(struct btd_service *service);
 void input_device_unregister(struct btd_service *service);

--- a/profiles/input/input.conf
+++ b/profiles/input/input.conf
@@ -24,3 +24,7 @@
 # Enables upgrades of security automatically if required.
 # Defaults to true to maximize device compatibility.
 #LEAutoSecurity=true
+
+# Exclude adapters
+# Disables input plugin on adapters with specified bdaddrs
+#ExcludeAdapters=00:00:00:00:00:00,00:00:00:00:00:01


### PR DESCRIPTION
As a bluez user I have run into cases where the input plugin can be problematic because it binds both HID PSMs on all bluetooth adapters. Simply disabling the plugin is not an ideal solution if you want to, for example, run an application that binds PSMs 17 and 19 on adapterA while using a bluetooth input device on adapterB. This change would allow users to select which of their adapters is used by the input plugin by specifying a comma separated list of bdaddrs in input.conf.