### PR TITLE
shared/util: Correct UUID for Microphone Control

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -338,7 +338,7 @@ static const struct {
 	{ 0x1849, "Generic Media Control"			},
 	{ 0x184b, "Telephony Bearer"				},
 	{ 0x184c, "Generic Telephony Bearer"			},
-	{ 0x184c, "Microphone Control"				},
+	{ 0x184d, "Microphone Control"				},
 	{ 0x184e, "Audio Stream Control"			},
 	{ 0x184f, "Broadcast Audio Scan"			},
 	{ 0x1850, "Published Audio Capabilities"		},


### PR DESCRIPTION
According to the Bluetooth product specification list, the allocated
UUID for "Microphone Control" is 0x184D, not 0x184C.