### PR TITLE
Blacklist Nissan Connect for autopairing

### DIFF
--- a/plugins/autopair.c
+++ b/plugins/autopair.c
@@ -66,6 +66,9 @@ static ssize_t autopair_pincb(struct btd_adapter *adapter,
 	/* The iCade shouldn't use random PINs like normal keyboards */
 	if (strstr(name, "iCade") != NULL)
 		return 0;
+	/* Nissan Connect carkits use PIN 1234 but refuse a retry */
+	if (name != NULL && strstr(name, "NISSAN CONNECT") != NULL)
+		return 0;
 
 	/* This is a class-based pincode guesser. Ignore devices with an
 	 * unknown class.


### PR DESCRIPTION
This took me hours to understand and a lot of btmon debugging:

- Nissan Connect displays "Use the code 1234 on your device" or similar text while pairing
- Bluez autopair plugin indeed has 1234 in its list of codes to try
- But the carkit does not allow any retry and will fail the whole pairing after "0000" has been sent on the first round of tries.

I decided to add a blacklist similar to the "iCade" thingie rather than messing with the order of codes to try. I still think "0000" is the most used one, so it should stay in the first slot.

Maybe for the future a better blacklisting facility would make sense. Expect that since we use Bluez now in the Ubuntu Touch mobile device ecosystem we see a lot more devices not being used on desktop, and some of them might be non-compliant with the expectations expressed in this plugin.