### PR TITLE
gdbus: fix stack var overflow

### DIFF
--- a/gdbus/client.c
+++ b/gdbus/client.c
@@ -215,7 +215,7 @@ static void iter_append_iter(DBusMessageIter *base, DBusMessageIter *iter)
 	type = dbus_message_iter_get_arg_type(iter);
 
 	if (dbus_type_is_basic(type)) {
-		const void *value;
+		DBusBasicValue value;
 
 		dbus_message_iter_get_basic(iter, &value);
 		dbus_message_iter_append_basic(base, type, &value);


### PR DESCRIPTION
When the type of basic value is double, can't using void *value as buffer to get value.

==3263760==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xefe13c30 at pc 0x577c0356 bp 0xefe139b8 sp 0xefe139a8 WRITE of size 8 at 0xefe13c30 thread T0
    #0 0x577c0355 in _dbus_marshal_read_basic dbus/dbus/dbus-marshal-basic.c:581
    #1 0x5783bedb in _dbus_type_reader_read_basic dbus/dbus/dbus-marshal-recursive.c:879
    #2 0x5776ef72 in dbus_message_iter_get_basic dbus/dbus/dbus-message.c:2376
    #3 0x57e06daa in iter_append_iter gdbus/client.c:222
    #4 0x57e070b1 in prop_entry_update gdbus/client.c:265
    #5 0x57e07454 in prop_entry_new gdbus/client.c:286
    #6 0x57e0793a in add_property gdbus/client.c:322