### PR TITLE
fix: rfcomm loads the CPU

### DIFF
--- a/tools/rfcomm.c
+++ b/tools/rfcomm.c
@@ -245,7 +245,7 @@ static void run_cmdline(struct pollfd *p, sigset_t *sigs, char *devname,
 
 			p->revents = 0;
 			ts.tv_sec  = 0;
-			ts.tv_nsec = 200;
+			ts.tv_nsec = 200000000;
 			if (ppoll(p, 1, &ts, sigs) || __io_canceled) {
 				kill(pid, SIGTERM);
 				waitpid(pid, &status, 0);


### PR DESCRIPTION
*rfcomm watch checks if the child process has exited once every 200 nanoseconds*

before:
![before](https://github.com/bluez/bluez/assets/131992312/93589736-2c4a-40a0-8748-189419948b0b)
___
after fix:
![after](https://github.com/bluez/bluez/assets/131992312/a587e35b-5ff7-46de-b219-5231d68ac898)
