### PR TITLE
configure: Check ell path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,9 +298,10 @@ if (test "${enable_external_ell}" = "yes"); then
 	AC_SUBST(ELL_LIBS)
 fi
 if (test "${enable_external_ell}" != "yes"); then
-	AC_CHECK_FILE(${srcdir}/ell/ell.h, dummy=yes,
-			AC_CHECK_FILE(${srcdir}/../ell/ell/ell.h, dummy=yes,
-				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)))
+	if (test ! -f ${srcdir}/ell/ell.h) &&
+			(test ! -f ${srcdir}/../ell/ell/ell.h); then
+				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)
+	fi
 fi
 AM_CONDITIONAL(EXTERNAL_ELL, test "${enable_external_ell}" = "yes" ||
 				(test "${enable_btpclient}" != "yes" &&


### PR DESCRIPTION
Use of AC_CHECK_FILE prevents cross compilation.
Instead use test to support cross compiling.

- fixes #545 and fixes regression introduced by 1106b28 during cross compiling