### PR TITLE
Fix missing "SIOCGSTAMP" on newer linux kernels

### DIFF
--- a/tools/l2test.c
+++ b/tools/l2test.c
@@ -29,6 +29,7 @@
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <linux/sockios.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"

--- a/tools/rctest.c
+++ b/tools/rctest.c
@@ -27,6 +27,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <linux/sockios.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"


### PR DESCRIPTION
Added "linux/sockios.h" to prevent missing "SIOCGSTAMP" on newer linux kernels.

Based on: https://github.com/LibtraceTeam/libtrace/commit/cd7f4c79aa55823d2e3be9b753088c40bc44d183

Screenshot of original issue:
![image](https://github.com/bluez/bluez/assets/34610663/2a6441c6-3b0c-481e-afd0-b60b785aca97)
