### PR TITLE
Fix for issue #563: Compile with configure --disable-hog fails 

### DIFF
--- a/profiles/input/device.h
+++ b/profiles/input/device.h
@@ -18,7 +18,7 @@ void input_set_idle_timeout(int timeout);
 void input_enable_userspace_hid(bool state);
 void input_set_classic_bonded_only(bool state);
 bool input_get_classic_bonded_only(void);
-void input_set_auto_sec(bool state);
+bool input_get_auto_sec();
 
 int input_device_register(struct btd_service *service);
 void input_device_unregister(struct btd_service *service);

--- a/profiles/input/hog.c
+++ b/profiles/input/hog.c
@@ -53,13 +53,7 @@ struct hog_device {
 };
 
 static gboolean suspend_supported = FALSE;
-static bool auto_sec = true;
 static struct queue *devices = NULL;
-
-void input_set_auto_sec(bool state)
-{
-	auto_sec = state;
-}
 
 static void hog_device_accept(struct hog_device *dev, struct gatt_db *db)
 {
@@ -185,7 +179,7 @@ static int hog_accept(struct btd_service *service)
 	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device))) {
 		struct bt_gatt_client *client;
 
-		if (!auto_sec)
+		if (!input_get_auto_sec())
 			return -ECONNREFUSED;
 
 		client = btd_device_get_gatt_client(device);

--- a/profiles/input/manager.c
+++ b/profiles/input/manager.c
@@ -30,6 +30,13 @@
 #include "device.h"
 #include "server.h"
 
+static bool auto_sec_global = true;
+
+bool input_get_auto_sec()
+{
+	return auto_sec_global;
+}
+
 static int hid_server_probe(struct btd_profile *p, struct btd_adapter *adapter)
 {
 	return server_start(btd_adapter_get_address(adapter));
@@ -117,7 +124,7 @@ static int input_init(void)
 		if (!err) {
 			DBG("input.conf: LEAutoSecurity=%s",
 					auto_sec ? "true" : "false");
-			input_set_auto_sec(auto_sec);
+			auto_sec_global = auto_sec
 		} else
 			g_clear_error(&err);
 

--- a/profiles/input/manager.c
+++ b/profiles/input/manager.c
@@ -124,7 +124,7 @@ static int input_init(void)
 		if (!err) {
 			DBG("input.conf: LEAutoSecurity=%s",
 					auto_sec ? "true" : "false");
-			auto_sec_global = auto_sec
+			auto_sec_global = auto_sec;
 		} else
 			g_clear_error(&err);
 


### PR DESCRIPTION
Hi,

tested compilation and function of bluetoothd with --disable-hog.

did NOT test bluetoothd with HOG enabled.

regards,
dezi