### PR TITLE
configure.ac: Add enable_btpclient and enable_mesh for internal ELL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -301,7 +301,8 @@ if (test "${enable_external_ell}" = "yes"); then
 	AC_SUBST(ELL_CFLAGS)
 	AC_SUBST(ELL_LIBS)
 fi
-if (test "${enable_external_ell}" != "yes"); then
+if (test "${enable_external_ell}" != "yes" &&
+		(test "${enable_btpclient}" = "yes" && test "${enable_mesh}" = "yes")); then
 	if (test ! -f ${srcdir}/ell/ell.h) &&
 			(test ! -f ${srcdir}/../ell/ell/ell.h); then
 				AC_MSG_ERROR(ELL source is required or use --enable-external-ell)


### PR DESCRIPTION
when enable_external_ell is not specified, confiugre doesn't not check if enable_btpclient and enable_mesh are enabled.
this causes the internal ELL must be installed.