### PR TITLE
Added support for VOYEE HY-2208 identified as GUO HUA PS3 GamePad

### DIFF
--- a/profiles/input/sixaxis.h
+++ b/profiles/input/sixaxis.h
@@ -49,6 +49,14 @@ get_pairing(uint16_t vid, uint16_t pid, const char *name)
 			.type = CABLE_PAIRING_SIXAXIS,
 		},
 		{
+			.name = "GUO HUA PS3 GamePad", // compatible with VOYEE - HY-2208
+			.source = 0x0002,
+			.vid = 0x054c,
+			.pid = 0x0268,
+			.version = 0x0000,
+			.type = CABLE_PAIRING_SIXAXIS,
+		},
+		{
 			.name = "Navigation Controller",
 			.source = 0x0002,
 			.vid = 0x054c,


### PR DESCRIPTION
Related issue #198

I tested it with my [VOYEE - HY-2208](https://www.amazon.com/VOYEE-Controller-Wireless-Dualshock-Playstation/dp/B07ZRSYWNB/) on my steamdeck. It works with no problems both over USB and over Bluetooth.