### PR TITLE
bluetooth.ver: remove undefined symbols

### DIFF
--- a/src/bluetooth.ver
+++ b/src/bluetooth.ver
@@ -3,8 +3,6 @@
 		btd_*;
 		g_dbus_*;
 		info;
-		error;
-		debug;
 		baswap;
 		ba2str;
 		/* Don't break LLVM sanitizers */


### PR DESCRIPTION
* error and debug only exists macros and not as symbols.

```
clang -DHAVE_CONFIG_H -I.   -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/elogind -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -pthread -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I./lib        -O3 -pipe -march=znver3 -flto=thin -c -o profiles/network/bnep.o profiles/network/bnep.c
/bin/sh ./libtool  --tag=CC   --mode=link clang       -O3 -pipe -march=znver3 -flto=thin  -Wl,--export-dynamic -Wl,--version-script=./src/bluetooth.ver -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -o src/bluetoothd plugins/bluetoothd-hostname.o plugins/bluetoothd-wiimote.o plugins/bluetoothd-autopair.o plugins/bluetoothd-policy.o    profiles/audio/bluetoothd-source.o profiles/audio/bluetoothd-sink.o profiles/audio/bluetoothd-a2dp.o profiles/audio/bluetoothd-avdtp.o profiles/audio/bluetoothd-media.o profiles/audio/bluetoothd-transport.o profiles/audio/bluetoothd-control.o profiles/audio/bluetoothd-avctp.o profiles/audio/bluetoothd-avrcp.o profiles/audio/bluetoothd-player.o profiles/network/bluetoothd-manager.o profiles/network/bluetoothd-bnep.o profiles/network/bluetoothd-server.o profiles/network/bluetoothd-connection.o profiles/input/bluetoothd-manager.o profiles/input/bluetoothd-server.o profiles/input/bluetoothd-device.o profiles/input/bluetoothd-hog.o profiles/input/bluetoothd-hog-lib.o profiles/deviceinfo/bluetoothd-dis.o profiles/battery/bluetoothd-bas.o profiles/scanparam/bluetoothd-scpp.o profiles/input/bluetoothd-suspend-none.o  profiles/gap/bluetoothd-gas.o profiles/scanparam/bluetoothd-scan.o profiles/deviceinfo/bluetoothd-deviceinfo.o  profiles/battery/bluetoothd-battery.o profiles/audio/bluetoothd-bap.o profiles/audio/bluetoothd-bass.o profiles/audio/bluetoothd-mcp.o profiles/audio/bluetoothd-vcp.o profiles/audio/bluetoothd-micp.o profiles/audio/bluetoothd-csip.o attrib/bluetoothd-att.o attrib/bluetoothd-gatt.o attrib/bluetoothd-gattrib.o btio/bluetoothd-btio.o src/bluetoothd-main.o src/bluetoothd-log.o src/bluetoothd-backtrace.o src/bluetoothd-rfkill.o src/bluetoothd-sdpd-server.o src/bluetoothd-sdpd-request.o src/bluetoothd-sdpd-service.o src/bluetoothd-sdpd-database.o src/bluetoothd-gatt-database.o src/bluetoothd-sdp-xml.o src/bluetoothd-sdp-client.o src/bluetoothd-textfile.o src/bluetoothd-uuid-helper.o src/bluetoothd-plugin.o src/bluetoothd-storage.o src/bluetoothd-advertising.o src/bluetoothd-agent.o src/bluetoothd-error.o src/bluetoothd-adapter.o src/bluetoothd-profile.o src/bluetoothd-service.o src/bluetoothd-gatt-client.o src/bluetoothd-device.o src/bluetoothd-dbus-common.o src/bluetoothd-eir.o src/bluetoothd-adv_monitor.o src/bluetoothd-battery.o src/bluetoothd-settings.o src/bluetoothd-set.o  lib/libbluetooth-internal.la gdbus/libgdbus-internal.la src/libshared-glib.la  -lglib-2.0 -lgthread-2.0 -pthread -lglib-2.0 -ldbus-1 -ldl -lrt  
libtool: link: clang -O3 -pipe -march=znver3 -flto=thin -Wl,--export-dynamic -Wl,--version-script=./src/bluetooth.ver -Wl,-O1 -Wl,--defsym=__gentoo_check_ldflags__=0 -o src/bluetoothd plugins/bluetoothd-hostname.o plugins/bluetoothd-wiimote.o plugins/bluetoothd-autopair.o plugins/bluetoothd-policy.o profiles/audio/bluetoothd-source.o profiles/audio/bluetoothd-sink.o profiles/audio/bluetoothd-a2dp.o profiles/audio/bluetoothd-avdtp.o profiles/audio/bluetoothd-media.o profiles/audio/bluetoothd-transport.o profiles/audio/bluetoothd-control.o profiles/audio/bluetoothd-avctp.o profiles/audio/bluetoothd-avrcp.o profiles/audio/bluetoothd-player.o profiles/network/bluetoothd-manager.o profiles/network/bluetoothd-bnep.o profiles/network/bluetoothd-server.o profiles/network/bluetoothd-connection.o profiles/input/bluetoothd-manager.o profiles/input/bluetoothd-server.o profiles/input/bluetoothd-device.o profiles/input/bluetoothd-hog.o profiles/input/bluetoothd-hog-lib.o profiles/deviceinfo/bluetoothd-dis.o profiles/battery/bluetoothd-bas.o profiles/scanparam/bluetoothd-scpp.o profiles/input/bluetoothd-suspend-none.o profiles/gap/bluetoothd-gas.o profiles/scanparam/bluetoothd-scan.o profiles/deviceinfo/bluetoothd-deviceinfo.o profiles/battery/bluetoothd-battery.o profiles/audio/bluetoothd-bap.o profiles/audio/bluetoothd-bass.o profiles/audio/bluetoothd-mcp.o profiles/audio/bluetoothd-vcp.o profiles/audio/bluetoothd-micp.o profiles/audio/bluetoothd-csip.o attrib/bluetoothd-att.o attrib/bluetoothd-gatt.o attrib/bluetoothd-gattrib.o btio/bluetoothd-btio.o src/bluetoothd-main.o src/bluetoothd-log.o src/bluetoothd-backtrace.o src/bluetoothd-rfkill.o src/bluetoothd-sdpd-server.o src/bluetoothd-sdpd-request.o src/bluetoothd-sdpd-service.o src/bluetoothd-sdpd-database.o src/bluetoothd-gatt-database.o src/bluetoothd-sdp-xml.o src/bluetoothd-sdp-client.o src/bluetoothd-textfile.o src/bluetoothd-uuid-helper.o src/bluetoothd-plugin.o src/bluetoothd-storage.o src/bluetoothd-advertising.o src/bluetoothd-agent.o src/bluetoothd-error.o src/bluetoothd-adapter.o src/bluetoothd-profile.o src/bluetoothd-service.o src/bluetoothd-gatt-client.o src/bluetoothd-device.o src/bluetoothd-dbus-common.o src/bluetoothd-eir.o src/bluetoothd-adv_monitor.o src/bluetoothd-battery.o src/bluetoothd-settings.o src/bluetoothd-set.o  -Wl,--as-needed lib/.libs/libbluetooth-internal.a gdbus/.libs/libgdbus-internal.a src/.libs/libshared-glib.a -lgthread-2.0 -lglib-2.0 -ldbus-1 -ldl -lrt -pthread
ld.lld: error: version script assignment of 'global' to symbol 'error' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'debug' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Bug: https://bugs.gentoo.org/915205