### PR TITLE
Misc build fixes to fix build with musl and clang/LLD

### DIFF
--- a/android/client/if-hf-client.c
+++ b/android/client/if-hf-client.c
@@ -7,6 +7,7 @@
 #define _GNU_SOURCE
 #include "if-main.h"
 #include "../hal-utils.h"
+#include <string.h>
 
 const bthf_client_interface_t *if_hf_client = NULL;
 

--- a/emulator/vhci.c
+++ b/emulator/vhci.c
@@ -13,16 +13,14 @@
 #include <config.h>
 #endif
 
-#include <stdio.h>
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/uio.h>
-#include <fcntl.h>
 #include <unistd.h>
-#include <dirent.h>
 
 #include "lib/bluetooth.h"
 #include "lib/hci.h"

--- a/emulator/vhci.c
+++ b/emulator/vhci.c
@@ -16,6 +16,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/bluetooth.ver
+++ b/src/bluetooth.ver
@@ -3,8 +3,6 @@
 		btd_*;
 		g_dbus_*;
 		info;
-		error;
-		debug;
 		baswap;
 		ba2str;
 		/* Don't break LLVM sanitizers */


### PR DESCRIPTION
A couple of fixes to allow building bluez with the LLVM toolchain (version 17.0.2) on a musl based system
- `emulator/vhci.c` used `PATH_MAX` without including `<limits.h>`
- `android/client/if-hf-client.c` used `memset` without including `<string.h>`
- `src/bluetooth.ver` listed `debug` and `error` symbols which aren't defined anymore