### PR TITLE
Draft: device: Try to connect again later if all slots for connecting are used 

### DIFF
--- a/btio/btio.c
+++ b/btio/btio.c
@@ -221,10 +221,13 @@ static gboolean connect_cb(GIOChannel *io, GIOCondition cond,
 
 	sock = g_io_channel_unix_get_fd(io);
 
-	if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
+	if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0) {
 		err = -errno;
-	else
+	} else {
 		err = -sk_err;
+		if (err == -ECONNREFUSED || err == -EIO)
+			err = -EAGAIN;
+	}
 
 	if (err < 0) {
 		ba2str(&conn->dst, addr);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -25,6 +25,7 @@
 
 struct btd_adapter;
 struct btd_device;
+struct btd_service;
 struct queue;
 
 struct btd_adapter *btd_adapter_get_default(void);
@@ -288,3 +289,7 @@ bool btd_adapter_set_allowed_uuids(struct btd_adapter *adapter,
 							struct queue *uuids);
 bool btd_adapter_is_uuid_allowed(struct btd_adapter *adapter,
 							const char *uuid_str);
+
+void btd_adapter_add_to_try_later_list(struct btd_adapter *adapter, struct btd_service *service);
+
+void btd_adapter_run_try_later_list(struct btd_adapter *adapter);

--- a/src/sdp-client.c
+++ b/src/sdp-client.c
@@ -245,10 +245,13 @@ static gboolean connect_watch(GIOChannel *chan, GIOCondition cond,
 	ctxt->io_id = 0;
 
 	len = sizeof(sk_err);
-	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0)
+	if (getsockopt(sk, SOL_SOCKET, SO_ERROR, &sk_err, &len) < 0) {
 		err = -errno;
-	else
+	} else {
 		err = -sk_err;
+		if (err == -ECONNREFUSED || err == -EIO)
+			err = -EAGAIN;
+	}
 
 	if (err != 0)
 		goto failed;


### PR DESCRIPTION
Most adapters can only establish connections to a limited amount of
devices at the same, after that the "Create Connection" HCI requests
will fail (sometimes immediately, sometimes asynchronously).

With the last commits, we introduced some infrastructure to set the
error code to EAGAIN in case these "slots" for new connections are
exhausted. Let's make use of this information and introduce a new
try_again_list on the adapter, where we add the btd_service to that
list in case connecting the service failed with EAGAIN. When we see
a successful connection or a page timeout, we assume that the "slot"
on the adapter is free again and we go through the list and try to
connect each service again.

Tested on:
- Broadcomm BCM4387 (Macbook Pro M1)
- Marvell 88W8897 (Surface Pro 5)