### PR TITLE
monitor/intel: Add decoding of firmware SHA1 in read version event

### DIFF
--- a/monitor/intel.c
+++ b/monitor/intel.c
@@ -291,6 +291,7 @@ static const struct intel_version_tlv_desc {
 	{ 47, "SBE Type", print_version_tlv_u8 },
 	{ 48, "OTP BDADDR", print_version_tlv_otp_bdaddr },
 	{ 49, "Unlocked State", print_version_tlv_enabled },
+	{ 50, "Firmware SHA1", print_version_tlv_u32 },
 	{ 0, NULL, NULL },
 };
 


### PR DESCRIPTION
< HCI Command: Intel Read Version (0x3f|0x0005) plen 1
        Requested Type:
          All Supported Types(0xff)
> HCI Event: Command Complete (0x0e) plen 107
      Intel Read Version (0x3f|0x0005) ncmd 1
        Status: Success (0x00)
        CNVi TOP(16): 0x00400410
        CNVr TOP(17): 0x00400410
        CNVi BT(18): 0x00173700
        CNVr BT(19): 0x00123720
        CNVr OTP(21): 0x0413
        Device Rev ID(22): 0x0000
        USB VID(23): 0x8087
        USB PID(24): 0x0032
        Image Type(28): Firmware(0x03)
        Time Stamp(29): 23-42
        Build Type(30): 0x01
        Build Num(31): 0x00011d97
        FW Build Product(32): 0x06
        FW Build HW(33): 0x06
        FW Build Step(34): 0xa0
        BT Spec(35): 0x00
        Manufacturer(36): Intel Corp. (2)
        HCI Revision(37): 0x3597
        LMP SubVersion(38): 0x3597
        OTP Lock(42): Disabled(0)
        API Lock(43): Disabled(0)
        Firmware SHA1(50): 0x2e575f2a
        Unknown Type(51):
        00
        Unknown Type(52):
        Unknown Type(53):
        00 00 00 00