### PR TITLE
Fix format error in client/player.c, function transport_send_seq

### DIFF
--- a/client/player.c
+++ b/client/player.c
@@ -4374,7 +4374,7 @@ static int transport_send_seq(struct transport *transport, int fd, uint32_t num)
 		bt_shell_echo("[seq %d %d.%03ds] send: %zd/%zd bytes",
 				transport->seq, secs,
 				(nsecs + 500000) / 1000000,
-				offset, transport->stat.st_size);
+				(size_t) offset, (size_t) transport->stat.st_size);
 	}
 
 	free(buf);


### PR DESCRIPTION
Fix format error in client/player.c, function transport_send_seq:

```
make --no-print-directory all-am
  CC       client/player.o
client/player.c: In function ‘transport_send_seq’:
client/player.c:4374:44: error: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 5 has type ‘off_t’ {aka ‘long int’} [-Werror=format=]
 4374 |   bt_shell_echo("[seq %d %d.%03ds] send: %zd/%zd bytes",
      |                                          ~~^
      |                                            |
      |                                            int
      |                                          %ld
......
 4377 |     offset, transport->stat.st_size);
      |     ~~~~~~
      |     |
      |     off_t {aka long int}
client/player.c:4374:48: error: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 6 has type ‘__off_t’ {aka ‘long int’} [-Werror=format=]
 4374 |   bt_shell_echo("[seq %d %d.%03ds] send: %zd/%zd bytes",
      |                                              ~~^
      |                                                |
      |                                                int
      |                                              %ld
......
 4377 |     offset, transport->stat.st_size);
      |             ~~~~~~~~~~~~~~~~~~~~~~~
      |                            |
      |                            __off_t {aka long int}
```