### PR TITLE
 client: Remove Pygments dependency from manpage

### DIFF
--- a/client/bluetoothctl.rst
+++ b/client/bluetoothctl.rst
@@ -339,7 +339,7 @@ AUTOMATION
 Two common ways to automate the tool are to use Here Docs or the program expect.
 Using Here Docs to show information about the Bluetooth controller.
 
-.. code:: bash
+.. code::
 
    bluetoothctl <<EOF
    list


### PR DESCRIPTION
This patch removes the Pygments dependency from bluetoothctl.rst file. When the code-block type is specified, the rst2man throws a warning asking for Pygments package.
(ref https://github.com/bluez/bluez/commit/fa57cb68e13ea4a6cff5532830008d44254e7e83)