### PR TITLE
Added state variable for MIDI BLE timestamp handling, addresses #471

### DIFF
--- a/profiles/midi/libmidi.c
+++ b/profiles/midi/libmidi.c
@@ -110,6 +110,7 @@ int midi_read_init(struct midi_read_parser *parser)
 	parser->timestamp = 0;
 	parser->timestamp_low = 0;
 	parser->timestamp_high = 0;
+	parser->timestamp_set = false;
 
 	parser->sysex_stream.data = malloc(MIDI_SYSEX_MAX_SIZE);
 	if (!parser->sysex_stream.data)
@@ -355,9 +356,10 @@ size_t midi_read_raw(struct midi_read_parser *parser, const uint8_t *data,
 	size_t i = 0;
 	bool err = false;
 
-	if (parser->timestamp_high == 0)
+	if (!parser->timestamp_set) { /* Has timestamp byte been read */
 		parser->timestamp_high = data[i++] & 0x3F;
-
+		parser->timestamp_set = true;
+	}
 	snd_midi_event_reset_encode(parser->midi_ev);
 
 	/* timestamp byte */

--- a/profiles/midi/libmidi.h
+++ b/profiles/midi/libmidi.h
@@ -81,6 +81,7 @@ struct midi_read_parser {
 	uint8_t rstatus;                 /* running status byte */
 	int64_t rtime;                   /* last reader's real time */
 	int16_t timestamp;               /* last MIDI-BLE timestamp */
+	bool timestamp_set;				 /* Has the current timestamp been set*/
 	int8_t timestamp_low;            /* MIDI-BLE timestampLow from the current packet */
 	int8_t timestamp_high;           /* MIDI-BLE timestampHigh from the current packet */
 	struct midi_buffer sysex_stream; /* SysEx stream */
@@ -100,6 +101,7 @@ static inline void midi_read_reset(struct midi_read_parser *parser)
 	parser->rstatus = 0;
 	parser->timestamp_low = 0;
 	parser->timestamp_high = 0;
+	parser->timestamp_set = false;
 }
 
 /* Parses raw BLE-MIDI messages and populates a sequencer event representing the


### PR DESCRIPTION
Added a boolean to the midi_read_parser struct to keep track of setting the initial timestamp_high byte. Addresses MIDI controllers sending timestamp as all zeros. My first ever PR, dunno if I'm doing it right.