### PR TITLE
tools/hex2hcd: fix musl compatibility

### DIFF
--- a/tools/hex2hcd.c
+++ b/tools/hex2hcd.c
@@ -285,6 +285,11 @@ static void ver_parse_file(const char *pathname)
 	prev->next = ver;
 }
 
+static const char *helper_basename(const char *path) {
+  const char *base = strrchr(path, '/');
+  return base ? base + 1 : path;
+}
+
 static void ver_parse_entry(const char *pathname)
 {
 	struct stat st;
@@ -302,7 +307,7 @@ static void ver_parse_entry(const char *pathname)
 	}
 
 	if (S_ISREG(st.st_mode)) {
-		ver_parse_file(basename(pathname));
+		ver_parse_file(helper_basename(pathname));
 		goto done;
 	}
 


### PR DESCRIPTION
The call to basename() relies on a GNU extension
to take a const char * vs a char *. Let's define
a trivial helper function to ensure compatibility
with musl.