### PR TITLE
src/device.c: Fixed a connection that could not receive Bluetooth Low Energy devices.

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -6063,6 +6063,10 @@ void btd_device_set_temporary(struct btd_device *device, bool temporary)
 
 	if (device->bredr)
 		adapter_accept_list_add(device->adapter, device);
+	else if (device->le) {
+		device->disable_auto_connect = FALSE;
+		device_set_auto_connect(device, TRUE);
+	}
 
 	store_device_info(device);
 


### PR DESCRIPTION
    src/device.c: Fixed a connection that could not receive Bluetooth Low Energy devices.
    
    Bluez version is greater than or equal to 5.69 , when paired successfully, turn Bluetooth off
and then on, unable to receive a low-power mouse and keyboard connection.After pairing successfully,
low power mouse and keyboard connections cannot be received.
    
    After analysis, the mgmt command(MGMT_OP_ADD_DEVICE) was not sent to the kernel after the pairing
connection was completed.
    
    Fixes: https://github.com/bluez/bluez/issues/902
    
    Signed-off-by: caitao123456789 <caitao@kylinos.cn>