### PR TITLE
src/device.c: Fixed a connection that could not receive Bluetooth Low Energy devices.

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -2323,6 +2323,25 @@ static struct btd_service *find_connectable_service(struct btd_device *dev,
 	return NULL;
 }
 
+
+static bool device_is_set_auto_connect(struct btd_device *dev)
+{
+	if (dev->services) {
+		GSList *l;
+
+		for (l = dev->services; l != NULL; l = g_slist_next(l)) {
+			struct btd_service *service = l->data;
+			struct btd_profile *p = btd_service_get_profile(service);
+
+			if (p->auto_connect && p->accept)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+
 static int service_prio_cmp(gconstpointer a, gconstpointer b)
 {
 	struct btd_profile *p1 = btd_service_get_profile(a);
@@ -6063,7 +6082,7 @@ void btd_device_set_temporary(struct btd_device *device, bool temporary)
 
 	if (device->bredr)
 		adapter_accept_list_add(device->adapter, device);
-	else if (device->le) {
+	else if (device->le && device_is_set_auto_connect(device)) {
 		device->disable_auto_connect = FALSE;
 		device_set_auto_connect(device, TRUE);
 	}

--- a/src/device.c
+++ b/src/device.c
@@ -6063,6 +6063,10 @@ void btd_device_set_temporary(struct btd_device *device, bool temporary)
 
 	if (device->bredr)
 		adapter_accept_list_add(device->adapter, device);
+	else if (device->le) {
+		device->disable_auto_connect = FALSE;
+		device_set_auto_connect(device, TRUE);
+	}
 
 	store_device_info(device);
 

--- a/src/device.c
+++ b/src/device.c
@@ -2323,25 +2323,6 @@ static struct btd_service *find_connectable_service(struct btd_device *dev,
 	return NULL;
 }
 
-
-static bool device_is_set_auto_connect(struct btd_device *dev)
-{
-	if (dev->services) {
-		GSList *l;
-
-		for (l = dev->services; l != NULL; l = g_slist_next(l)) {
-			struct btd_service *service = l->data;
-			struct btd_profile *p = btd_service_get_profile(service);
-
-			if (p->auto_connect && p->accept)
-				return true;
-		}
-	}
-
-	return false;
-}
-
-
 static int service_prio_cmp(gconstpointer a, gconstpointer b)
 {
 	struct btd_profile *p1 = btd_service_get_profile(a);
@@ -6082,7 +6063,7 @@ void btd_device_set_temporary(struct btd_device *device, bool temporary)
 
 	if (device->bredr)
 		adapter_accept_list_add(device->adapter, device);
-	else if (device->le && device_is_set_auto_connect(device)) {
+	else if (device->le && device->disable_auto_connect) {
 		device->disable_auto_connect = FALSE;
 		device_set_auto_connect(device, TRUE);
 	}


### PR DESCRIPTION
src/device.c: Fixed a connection that could not receive Bluetooth Low Energy devices.

Bluez version is greater than or equal to 5.69 , when paired successfully, turn Bluetooth off and then on, unable to receive a low-power mouse and keyboard connection.After pairing successfully, low power mouse and keyboard connections cannot be received.

After analysis, the mgmt command(MGMT_OP_ADD_DEVICE) was not sent to the kernel after the pairing connection was completed.

Fixes: https://github.com/bluez/bluez/issues/902