### PR TITLE
profiles/battery: Fix random broken battery percentage

### DIFF
--- a/profiles/battery/battery.c
+++ b/profiles/battery/battery.c
@@ -94,13 +94,15 @@ static void parse_battery_level(struct batt *batt,
 	uint8_t percentage;
 
 	percentage = value[0];
+	
+	if (!batt->battery) {
+		warn("Trying to update an unregistered battery");
+		return;
+	}
+	
 	if (batt->percentage != percentage) {
 		batt->percentage = percentage;
 		DBG("Battery Level updated: %d%%", percentage);
-		if (!batt->battery) {
-			warn("Trying to update an unregistered battery");
-			return;
-		}
 		btd_battery_update(batt->battery, batt->percentage);
 	}
 }


### PR DESCRIPTION
profiles/battery/battery.c:batt_io_value_cb() may be run earlier than profiles/battery/battery.c:batt_io_ccc_written_cb(), which causes the percentage to be updated in the batt structure when the dbus interface has not been registered.

After the dbus interface is registered, the function to update the battery percentage is skipped again because the battery level has not changed yet.