### PR TITLE
Set `SDP_LARGE_MTU` for Dualshock 4 (Rev. 2)

### DIFF
--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -1643,7 +1643,7 @@ int input_device_set_channel(const bdaddr_t *src, const bdaddr_t *dst, int psm,
 	}
 
 	if (idev->intr_io && idev->ctrl_io)
-		input_device_connadd(idev);
+		return input_device_connadd(idev);
 
 	return 0;
 }

--- a/profiles/input/device.c
+++ b/profiles/input/device.c
@@ -1643,7 +1643,7 @@ int input_device_set_channel(const bdaddr_t *src, const bdaddr_t *dst, int psm,
 	}
 
 	if (idev->intr_io && idev->ctrl_io)
-		return input_device_connadd(idev);
+		input_device_connadd(idev);
 
 	return 0;
 }

--- a/src/device.c
+++ b/src/device.c
@@ -6047,7 +6047,7 @@ static uint16_t get_sdp_flags(struct btd_device *device)
 	 * results in SDP response being dropped by kernel. Workaround this by
 	 * forcing SDP code to use bigger MTU while connecting.
 	 */
-	if (vid == 0x054c && pid == 0x05c4)
+	if (vid == 0x054c && (pid == 0x05c4 || pid == 0x09cc))
 		return SDP_LARGE_MTU;
 
 	if (btd_adapter_ssp_enabled(device->adapter))


### PR DESCRIPTION
A fix for https://github.com/bluez/bluez/issues/1034

Other related issues
https://github.com/bluez/bluez/issues/834
https://github.com/bluez/bluez/issues/702
