### PR TITLE
Avoid spurious warnings when dbus.service stops

### DIFF
--- a/tools/mpris-proxy.service.in
+++ b/tools/mpris-proxy.service.in
@@ -3,7 +3,7 @@ Description=Bluetooth mpris proxy
 Documentation=man:mpris-proxy(1)
 
 Wants=dbus.socket
-After=dbus.socket
+After=dbus.socket dbus.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd services generates a warning when it loses ownership of its D-Bus name, which happens routinely when dbus.service exits (e.g. when the user logs out).

FYI, a similar issue in xdg-desktop-portal is addressed by flatpak/xdg-desktop-portal#1645.