### PR TITLE
configure.ac: check for stdio.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_CHECK_LIB(pthread, pthread_create, dummy=yes,
 AC_CHECK_LIB(dl, dlopen, dummy=yes,
 			AC_MSG_ERROR(dynamic linking loader is required))
 
-AC_CHECK_HEADERS(string.h linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
+AC_CHECK_HEADERS(stdio.h string.h linux/types.h linux/if_alg.h linux/uinput.h linux/uhid.h sys/random.h)
 
 # basename may be only available in libgen.h with the POSIX behavior,
 # not desired here


### PR DESCRIPTION
This fixes a configure failure for readline.h with slibtoolize which depends on HAVE_STDIO_H being defined. With GNU libtoolize this check is implicit and with slibtoolize it will fail instead.
```
error: unknown type name 'FILE'
```
Since bluez depends on stdio.h itself there is no reason to not check for it explicitly.

Gentoo-Issue: https://bugs.gentoo.org/950467