### PR TITLE
plugins/phonebook-ebook: clear pointers in `phonebook_exit`

### DIFF
--- a/obexd/plugins/phonebook-ebook.c
+++ b/obexd/plugins/phonebook-ebook.c
@@ -661,7 +661,7 @@ int phonebook_init(void)
 
 void phonebook_exit(void)
 {
-	g_object_unref(book_client);
-	g_object_unref(address_book);
-	g_object_unref(registry);
+	g_clear_object(&book_client);
+	g_clear_object(&address_book);
+	g_clear_object(&registry);
 }


### PR DESCRIPTION
This fixes a segfault observed when the dbus connection is lost:
```
#0  g_type_check_instance_is_fundamentally_a (type_instance=type_instance@entry=0xffff8308d990, fundamental_type=fundamental_type@entry=0x50 [GObject]) at ../gobject/gtype.c:3918
#1  0x0000ffff82dd51a0 in g_object_unref (_object=0xffff8308d990) at ../gobject/gobject.c:4335
#2  0x0000aaaac8eb4530 in phonebook_exit ()
#3  0x0000aaaac8eb805c in plugin_cleanup ()
#4  0x0000aaaac8ea0a68 in main ()
```