### PR TITLE
fix(gatt_conn_new): Typo after GATT client creation

### DIFF
--- a/peripheral/gatt.c
+++ b/peripheral/gatt.c
@@ -124,7 +124,7 @@ static struct gatt_conn *gatt_conn_new(int fd)
 	}
 
 	conn->client = bt_gatt_client_new(gatt_cache, conn->att, mtu, 0);
-	if (!conn->gatt) {
+	if (!conn->client) {
 		fprintf(stderr, "Failed to create GATT client\n");
 		bt_gatt_server_unref(conn->gatt);
 		bt_att_unref(conn->att);


### PR DESCRIPTION
There seems to be a typo after GATT client creation in `gatt_conn_new` function. Shouldn't we check if `conn->client` is valid instead ?