### PR TITLE
Potential fix for code scanning alert no. 21: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -501,7 +501,7 @@ static void parse_mode_config(GKeyFile *config, const char *group,
 				const struct config_param *params,
 				size_t params_len)
 {
-	uint16_t i;
+	size_t i;
 
 	if (!config)
 		return;


### PR DESCRIPTION
Potential fix for [https://github.com/bluez/bluez/security/code-scanning/21](https://github.com/bluez/bluez/security/code-scanning/21)

To fix the issue, we need to ensure that the type of the loop variable `i` matches the type of `params_len`. Since `params_len` is of type `size_t`, the loop variable `i` should also be declared as `size_t`. This change ensures that the comparison `i < params_len` is performed between two values of the same type, avoiding any potential overflow or unexpected behavior.

The fix involves:
1. Changing the type of `i` from `uint16_t` to `size_t` in the `parse_mode_config` function.
2. Verifying that this change does not introduce any other issues in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
