### PR TITLE
Fix Control/Target/HS retry counter resetting

### DIFF
--- a/plugins/policy.c
+++ b/plugins/policy.c
@@ -383,6 +383,7 @@ static void hs_cb(struct btd_service *service, btd_service_state_t old_state,
 		else if (btd_service_get_state(sink) !=
 						BTD_SERVICE_STATE_CONNECTED)
 			policy_set_sink_timer(data);
+		data->hs_retries = 0;
 		break;
 	case BTD_SERVICE_STATE_DISCONNECTING:
 		break;
@@ -537,8 +538,6 @@ static void controller_cb(struct btd_service *service,
 				timeout_remove(data->ct_timer);
 				data->ct_timer = 0;
 			}
-		} else if (old_state == BTD_SERVICE_STATE_CONNECTED) {
-			data->ct_retries = 0;
 		}
 		break;
 	case BTD_SERVICE_STATE_CONNECTING:
@@ -548,6 +547,7 @@ static void controller_cb(struct btd_service *service,
 			timeout_remove(data->ct_timer);
 			data->ct_timer = 0;
 		}
+		data->ct_retries = 0;
 		break;
 	case BTD_SERVICE_STATE_DISCONNECTING:
 		break;
@@ -587,8 +587,6 @@ static void target_cb(struct btd_service *service,
 				timeout_remove(data->tg_timer);
 				data->tg_timer = 0;
 			}
-		} else if (old_state == BTD_SERVICE_STATE_CONNECTED) {
-			data->tg_retries = 0;
 		}
 		break;
 	case BTD_SERVICE_STATE_CONNECTING:
@@ -598,6 +596,7 @@ static void target_cb(struct btd_service *service,
 			timeout_remove(data->tg_timer);
 			data->tg_timer = 0;
 		}
+		data->tg_retries = 0;
 		break;
 	case BTD_SERVICE_STATE_DISCONNECTING:
 		break;


### PR DESCRIPTION
Using bluetooth headphones volume input control is not created half the time (xinput does not show input for device, volume can only be muted/unmuted). In that case trying to set volume fails with the following error:

`src/profile.c:ext_io_disconnected() Unable to get io data for Hands-Free Voice gateway: getpeername: Transport endpoint is not connected (107)`

Tracking down the issue, it seems that both devices try to open AVCTP channel at the same time every time. In that case, avrcp session is not started half the time due to the fact that ct_retries is never reset across successful connection. This counter is only reset when service state goes from CONNECTED to DISCONNECTED, but usually an extra DISCONNECTING state is reach before going to DISCONNECTED.

This PR reset the counter as soon as CONNECTED state is reached to avoid that. Likewise this reset Target and HS retry counters that seems to also be broken.