### PR TITLE
doc: sco.rst: BT_PHY is read-only

### DIFF
--- a/doc/sco.rst
+++ b/doc/sco.rst
@@ -188,7 +188,7 @@ Example:
 BT_PHY (since Linux 5.10)
 -------------------------
 
-Transport supported PHY(s), possible values:
+Transport supported PHY(s), read-only (no setsockopt support). Possible values:
 
 .. csv-table::
     :header: "Define", "Value", "Description"


### PR DESCRIPTION
The kernel is missing BT_PHY setsockopt support, as of 6.16-rc1.