### PR TITLE
obexd: Fix failure to register bt transport

### DIFF
--- a/obexd/src/logind.c
+++ b/obexd/src/logind.c
@@ -68,7 +68,7 @@ static int update(void)
 		return res;
 
 	if (state_is_active) {
-		if (!active)
+		if (active)
 			return 0;
 	} else {
 		res = sd_uid_get_seats(uid, 1, NULL);


### PR DESCRIPTION
Regurgitating the commit message:

On initial logind update, the internal 'active' state is FALSE. Where querying the current state (`sd_uid_get_state`) returns 'active' we do NOT want to short-circuit the update to the internal state value and ultimate transport initialisation.

---

I am guessing that this was a typo in the initial implementation [obexd: Unregister profiles when the user is inactive](https://github.com/bluez/bluez/commit/765356e80262a20c359ec7722a5590232442d0d3) which is where I landed having bisected for the error:

```
obexd[188706]: obexd/src/server.c:obex_server_init() No transport driver registered
obexd[188706]: obex_server_init failed
```
in my distro (ArchLinux)'s latest 5.83 version. I went from working bt file transfer to not working post upgrade. Dropping back to 5.82 resolved the issue and I went from there.

I haven't seen any other complaints about this yet, which leads me to speculate that IFF one upgrades, reboots (yuck!) and the systemd USER SPACE obexd service is thus loaded prior to login, then the mechanism that the implementation was aiming for (new seat detection) kicks in and the internal active state is correctly set and the bt transport initialised. This just didn't happen in my scenario.