### PR TITLE
transport/audio: fix build with a2dp support disabled

### DIFF
--- a/profiles/audio/transport.c
+++ b/profiles/audio/transport.c
@@ -2745,6 +2745,7 @@ void media_transport_update_volume(struct media_transport *transport,
 	if (volume < 0)
 		return;
 
+#ifdef HAVE_A2DP
 	if (media_endpoint_get_sep(transport->endpoint)) {
 		struct a2dp_transport *a2dp = transport->data;
 
@@ -2757,6 +2758,7 @@ void media_transport_update_volume(struct media_transport *transport,
 
 		a2dp->volume = volume;
 	}
+#endif
 	g_dbus_emit_property_changed(btd_get_dbus_connection(),
 					transport->path,
 					MEDIA_TRANSPORT_INTERFACE, "Volume");
@@ -2769,6 +2771,7 @@ int media_transport_get_device_volume(struct btd_device *dev)
 	if (dev == NULL)
 		return -1;
 
+#ifdef HAVE_A2DP
 	/* Attempt to locate the transport to get its volume */
 	for (l = transports; l; l = l->next) {
 		struct media_transport *transport = l->data;
@@ -2785,6 +2788,7 @@ int media_transport_get_device_volume(struct btd_device *dev)
 			return -1;
 		}
 	}
+#endif
 
 	/* If transport volume doesn't exists use device_volume */
 	return btd_device_get_volume(dev);
@@ -2798,6 +2802,7 @@ void media_transport_update_device_volume(struct btd_device *dev,
 	if (dev == NULL || volume < 0)
 		return;
 
+#ifdef HAVE_A2DP
 	/* Attempt to locate the transport to set its volume */
 	for (l = transports; l; l = l->next) {
 		struct media_transport *transport = l->data;
@@ -2814,6 +2819,7 @@ void media_transport_update_device_volume(struct btd_device *dev,
 			break;
 		}
 	}
+#endif
 
 	btd_device_set_volume(dev, volume);
 }


### PR DESCRIPTION
Fixes issue #1675:
```
    CCLD     src/bluetoothd
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: profiles/audio/bluetoothd-media.o: in function `endpoint_init_a2dp_sink':
  .../bluez-5.85/profiles/audio/media.c:728:(.text.endpoint_init_a2dp_sink+0x2b): undefined reference to `a2dp_add_sep'
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: profiles/audio/bluetoothd-media.o: in function `endpoint_init_a2dp_source':
  .../bluez-5.85/profiles/audio/media.c:715:(.text.endpoint_init_a2dp_source+0x28): undefined reference to `a2dp_add_sep'
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: profiles/audio/bluetoothd-media.o: in function `set_configuration':
  .../bluez-5.85/profiles/audio/media.c:512:(.text.set_config+0x35): undefined reference to `a2dp_setup_get_device'
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: .../bluez-5.85/profiles/audio/media.c:525:(.text.set_config+0x8c): undefined reference to `a2dp_setup_remote_path'
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: profiles/audio/bluetoothd-media.o: in function `media_endpoint_remove':
  .../bluez-5.85/profiles/audio/media.c:250:(.text.media_endpoint_remove+0xc): undefined reference to `a2dp_remove_sep'
  /usr/lib64/gcc/x86_64-suse-linux/bin/ld: profiles/audio/bluetoothd-media.o: in function `endpoint_reply':
  .../bluez-5.85/profiles/audio/media.c:361:(.text.endpoint_reply+0x267): undefined reference to `a2dp_parse_config_error'
  collect2: error: ld returned 1 exit status
  make[1]: *** [Makefile:5491: src/bluetoothd] Error 1
  make: *** [Makefile:4096: all] Error 2
```

- patch inspired by 61d3e447f9d47f03e5cbd55b805d7841ccc93319 ("transport: Fix build with A2DP support disabled")
- compile tested only
- specially the part in media.c around line 365 to 374 (``a2dp_parse_config_error``) is a wild guess
- handle with care ;-)