### PR TITLE
src/adapter.c: Re-pairing and reconnection are required after restart.

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -4423,7 +4423,7 @@ static void load_link_keys(struct btd_adapter *adapter, GSList *keys,
 		struct link_key_info *info = l->data;
 
 		bacpy(&key->addr.bdaddr, &info->bdaddr);
-		key->addr.type = info->bdaddr_type;
+		key->addr.type = BDADDR_BREDR;
 		key->type = info->type;
 		memcpy(key->val, info->key, 16);
 		key->pin_len = info->pin_len;


### PR DESCRIPTION
     After restarting the machine or the bluetoothd service, previously
paired Bluetooth BR/EDR devices require re-pairing to establish a connection.
     Previously paired Bluetooth BR/EDR devices, such as mobile phones,
laptops, or Bluetooth headsets, will update their device information and save it to device configuration files after receiving BLE signals. After restarting the machine, during the initialization process, the device address type is obtained using the function get_addr_type(), which returns BDADDR_LE_PUBLIC. This leads to an abnormal issuance of the Load Link Keys command. According to the description of Load Link Keys, the address type is only supported for BR/EDR.

    """
    Load Link Keys
    Command Code:		0x0012
    Controller Index:	<controller id>
    Command Parameters:	Debug_Keys (1 Octet)
			Key_Count (2 Octets)
			Address[] (6 Octets)
			Address_Type[] (1 Octet)
			Key_Type[] (1 Octet)
			Value[] (16 Octets)
			PIN_Length[] (1 Octet)
			...[]
    Possible values for the Address_Type parameter:
	0, BR/EDR
	1, Reserved (not in use)
	2, Reserved (not in use)
    """