### PR TITLE
retain const qualifier from pointer

### DIFF
--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -525,6 +525,7 @@ static int cmd_exec(const struct bt_shell_menu_entry *entry,
 	wordexp_t w;
 	size_t len;
 	char *man, *opt;
+	const char *man2, *opt2;
 	int flags = WRDE_NOCMD;
 	bool optargs = false;
 
@@ -547,24 +548,24 @@ static int cmd_exec(const struct bt_shell_menu_entry *entry,
 	}
 
 	/* Find last mandatory arguments */
-	man = strrchr(entry->arg, '>');
-	if (!man) {
+	man2 = strrchr(entry->arg, '>');
+	if (!man2) {
 		opt = strdup(entry->arg);
 		goto optional;
 	}
 
-	len = man - entry->arg;
+	len = man2 - entry->arg;
 	if (entry->arg[0] == '<')
 		man = strndup(entry->arg, len + 1);
 	else {
 		/* Find where mandatory arguments start */
-		opt = strrchr(entry->arg, '<');
+		opt2 = strrchr(entry->arg, '<');
 		/* Skip if mandatory arguments are not in the right format */
-		if (!opt || opt > man) {
+		if (!opt2 || opt2 > man2) {
 			opt = strdup(entry->arg);
 			goto optional;
 		}
-		man = strndup(opt, man - opt + 1);
+		man = strndup(opt2, man2 - opt2 + 1);
 		optargs = true;
 	}
 
@@ -972,6 +973,7 @@ static char *cmd_generator(const char *text, int state)
 	static bool default_menu_enabled, menu_enabled, submenu_enabled;
 	static const struct bt_shell_menu *menu;
 	char *cmd;
+	const char *cmd2;
 
 	if (!state) {
 		index = 0;
@@ -1009,11 +1011,11 @@ static char *cmd_generator(const char *text, int state)
 		if (cmd || menu != data.main)
 			return cmd;
 
-		cmd = strrchr(text, '.');
-		if (!cmd)
+		cmd2 = strrchr(text, '.');
+		if (!cmd2)
 			return NULL;
 
-		menu = find_menu(text, cmd - text, NULL);
+		menu = find_menu(text, cmd2 - text, NULL);
 		if (!menu)
 			return NULL;
 

--- a/src/textfile.c
+++ b/src/textfile.c
@@ -68,7 +68,8 @@ int create_filename(char *str, size_t size, const char *fmt, ...)
 static int create_dirs(const char *filename, const mode_t mode)
 {
 	struct stat st;
-	char dir[PATH_MAX + 1], *prev, *next;
+	char dir[PATH_MAX + 1];
+	const char *prev, *next;
 	int err;
 
 	err = stat(filename, &st);

--- a/tools/hciattach_ath3k.c
+++ b/tools/hciattach_ath3k.c
@@ -303,7 +303,7 @@ struct tag_info {
 
 static inline int update_char_count(const char *buf)
 {
-	char *end_ptr;
+	const char *end_ptr;
 
 	if (strstr(buf, "[") == buf) {
 		end_ptr = strstr(buf, "]");


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes:
- warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]