### PR TITLE
Fix mangling of numbered UHID GET_REPORT_REPLY payloads

### DIFF
--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -534,6 +534,7 @@ int bt_uhid_get_report_reply(struct bt_uhid *uhid, uint32_t id, uint8_t number,
 
 	if (number) {
 		rsp->data[len++] = number;
+		rsp->size++;
 		rsp->size += MIN(size, sizeof(rsp->data) - 1);
 	} else
 		rsp->size = MIN(size, sizeof(ev.u.input.data));


### PR DESCRIPTION
### Issue

In `src/shared/uhid.c`, the `bt_uhid_get_report_reply` routine has an off-by-one error which causes numbered `GET_REPORT_REPLY` payloads to be mangled. Specifically, the following lines are incorrect:

```c
	if (number) {
		rsp->data[len++] = number;
		rsp->size += MIN(size, sizeof(rsp->data) - 1);
	} else
```

If `number` is nonzero, the impact of these lines is this:
- `len = 1` (incremented from `0`)
- `rsp->data[0] = number`
- `rsp->size = size` (let's assume `size <= sizeof(rsp->data) - 1`)

Immediately after, the function `memcpy`s the input data into `rsp`:

```c
	memcpy(&rsp->data[len], data, rsp->size - len);
```

Since `len = 1` and `rsp->size = size`, this copies only `size - 1` bytes of `data` into `rsp`, thereby truncating the final byte

### Fix

Apply the following patch:

```patch
--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -534,6 +534,7 @@ int bt_uhid_get_report_reply(struct bt_uhid *uhid, uint32_t id, uint8_t number,

        if (number) {
                rsp->data[len++] = number;
+               rsp->size++;
                rsp->size += MIN(size, sizeof(rsp->data) - 1);
        } else
                rsp->size = MIN(size, sizeof(ev.u.input.data));
```

The use of `+=` in the current code suggests that this fix behaviour may match the original author's intent

I have verified this fix on my system. Specifically, it fixes my downstream problems (see below, under "Discovery")

Here is an alternative fix, which is a larger change but produces simpler logic:

```patch
--- a/src/shared/uhid.c
+++ b/src/shared/uhid.c
@@ -534,6 +534,7 @@ int bt_uhid_get_report_reply(struct bt_uhid *uhid, uint32_t id, uint8_t number,

        if (number) {
                rsp->data[len++] = number;
-                rsp->size += MIN(size, sizeof(rsp->data) - 1);
+                rsp->size = MIN(1 + size, sizeof(rsp->data));
        } else
                rsp->size = MIN(size, sizeof(ev.u.input.data));
```

This logic almost exactly matches [what's currently used in another function, `bt_uhid_input`](https://github.com/bluez/bluez/blob/c2d072641aa9015fdfab196d095566fea364d4dc/src/shared/uhid.c#L478-L479):

```c
	if (number) {
		req->data[len++] = number;
		req->size = 1 + MIN(size, sizeof(req->data) - 1);
	} else
```

### Affected Systems

I've observed this issue only on my own system, which is a Thinkpad p16s gen2 running NixOS 25.11.3695.d03088749a11 with bluez 5.84 on linux 6.12.64. The broken code still exists on bluez latest

To my eyes this issue should affect any system which sends a numbered `GET_REPORT` request to bluez

### Discovery

I discovered this issue because my external touchpad (a Clevetura CLVX S), worked fine over USB but not over Bluetooth. Specifically, I discovered that this bluez off-by-one error caused bad data to get sent to the kernel, which in turn caused the touchpad to be wrongly classified as a clickpad, which resulted in tap and click events failing

After applying the suggested patch, the device no longer gets classified as a clickpad, and taps and clicks work great!

### Disclaimer

I am not a bluez or hardware developer 😅. I diagnosed this issue in collaboration with ChatGPT. It provided much of the low-level technical knowledge, initial hypotheses, and research labor; I provided much of the higher-level guidance, refinement, and correction. I could not have completed this diagnosis without its help, and it could not have completed it without my guidance (it had a tendency to start to spin out...)