### PR TITLE
obexd/bip: Fix uninitialized memory and malformed XML in GetImage request

### DIFF
--- a/obexd/client/bip.c
+++ b/obexd/client/bip.c
@@ -38,9 +38,6 @@
 
 #define EOL_CHARS "\n"
 #define IMG_DESC_BEGIN "<image-descriptor version=\"1.0\">" EOL_CHARS
-#define IMG_BEGIN "<image encoding=\"%s\" pixel=\"%s\""
-#define IMG_TRANSFORM " transformation=\"%s\""
-#define IMG_END "/>" EOL_CHARS
 #define IMG_DESC_END "</image-descriptor>" EOL_CHARS
 
 static DBusConnection *conn;
@@ -206,9 +203,10 @@ static gboolean parse_get_image_dict(DBusMessage *msg, char **path,
 		goto failed;
 	dbus_message_iter_get_basic(&iter, path);
 	*path = g_strdup(*path);
+	
+	dbus_message_iter_next(&iter);
 	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
 		goto failed;
-	dbus_message_iter_next(&iter);
 	dbus_message_iter_get_basic(&iter, handle);
 	*handle = g_strdup(*handle);
 	dbus_message_iter_next(&iter);
@@ -231,7 +229,7 @@ static gboolean parse_get_image_dict(DBusMessage *msg, char **path,
 		switch (dbus_message_iter_get_arg_type(&value)) {
 		case DBUS_TYPE_STRING:
 			dbus_message_iter_get_basic(&value, &val);
-			if (g_str_equal(key, "pixel")) {
+            if (g_str_equal(key, "pixel")) {
 				if (!parse_pixel_range(val, NULL, NULL, NULL))
 					goto failed;
 				*pixel = g_strdup(val);
@@ -258,13 +256,11 @@ static gboolean parse_get_image_dict(DBusMessage *msg, char **path,
 		dbus_message_iter_next(&array);
 	}
 
-	if (*pixel == NULL)
-		*pixel = strdup("");
-	if (*encoding == NULL)
-		*encoding = strdup("");
-
-	DBG("pixel: '%s' encoding: '%s' maxsize: '%lu' transform: '%s'",
-			*pixel, *encoding, *maxsize, *transform
+	DBG("pixel: '%s' encoding: '%s' maxsize: '%llu' transform: '%s'",
+			*pixel ? *pixel : "",
+			*encoding ? *encoding : "",
+			(unsigned long long)*maxsize,
+			*transform ? *transform : ""
 	);
 
 	return TRUE;
@@ -283,7 +279,7 @@ static DBusMessage *get_image(DBusConnection *connection,
 	struct bip_avrcp_data *bip_avrcp = user_data;
 	char *handle = NULL, *image_path = NULL, *transform = NULL,
 		*encoding = NULL, *pixel = NULL;
-	uint64_t maxsize;
+	uint64_t maxsize = 0;
 	struct obc_transfer *transfer;
 	GObexHeader *header;
 	DBusMessage *reply = NULL;
@@ -310,11 +306,18 @@ static DBusMessage *get_image(DBusConnection *connection,
 	obc_transfer_add_header(transfer, header);
 
 	descriptor = g_string_new(IMG_DESC_BEGIN);
-	g_string_append_printf(descriptor, IMG_BEGIN, encoding, pixel);
+	g_string_append(descriptor, "<image");
+	if (encoding != NULL)
+		g_string_append_printf(descriptor, " encoding=\"%s\"", encoding);
+	if (pixel != NULL)
+		g_string_append_printf(descriptor, " pixel=\"%s\"", pixel);
+	if (maxsize > 0)
+		g_string_append_printf(descriptor, " maxsize=\"%llu\"", (unsigned long long)maxsize);
 	if (transform != NULL)
-		g_string_append_printf(descriptor, IMG_TRANSFORM, transform);
-	g_string_append(descriptor, IMG_END);
+		g_string_append_printf(descriptor, " transformation=\"%s\"", transform);
+	g_string_append(descriptor, "/>" EOL_CHARS);
 	descriptor = g_string_append(descriptor, IMG_DESC_END);
+	
 	header = g_obex_header_new_bytes(IMG_DESC_TAG, descriptor->str,
 						descriptor->len);
 	obc_transfer_add_header(transfer, header);


### PR DESCRIPTION
This commit addresses several defects in the AVRCP BIP GetImage
implementation that caused strict OBEX servers (e.g., Android)
to reject image transfers with "Precondition Failed (0x4C)".

1. Fix uninitialized memory read:
   In `get_image()`, the `maxsize` variable was not initialized. If the
   client omitted the "maxsize" key in the D-Bus dictionary, `maxsize`
   retained garbage data from the stack, leading to anomalous log entries
   (e.g., `maxsize: '94413920449768'`).

2. Fix malformed XML image descriptor:
   When D-Bus clients omitted the `pixel` or `encoding` parameters,
   `parse_get_image_dict()` improperly forced them to empty strings ("").
   This resulted in `get_image()` generating an invalid XML tag:
   `<image encoding="" pixel=""/>`.
   According to the BIP specification, omitted attributes should not be
   included in the XML element. The XML construction logic has been
   rewritten to dynamically append only the provided attributes, and the
   previously parsed but ignored `maxsize` attribute is now properly
   included if specified.

3. Fix D-Bus iterator advancement:
   Removed a redundant D-Bus type check in `parse_get_image_dict()`
   where the iterator was evaluated twice before calling
   `dbus_message_iter_next()`.

---

relevant log:

obexd[84170]: obexd/client/session.c:obc_session_unref() 0x55de7433e390: ref=2

obexd[84170]: obexd/client/bip.c:get_image()

obexd[84170]: obexd/client/bip.c:parse_get_image_dict()

obexd[84170]: obexd/client/bip.c:parse_get_image_dict() pixel: '' encoding: '' maxsize: '94413920449768' transform: '(null)'

obexd[84170]: obexd/client/transfer.c:obc_transfer_register() 0x55de7433e520 registered /org/bluez/obex/client/session0/transfer0

obexd[84170]: obexd/client/session.c:obc_session_ref() 0x55de7433e390: ref=3

obexd[84170]: obexd/client/session.c:obc_session_ref() 0x55de7433e390: ref=4

obexd[84170]: obexd/client/session.c:session_process_transfer() Transfer(0x55de7433e520) started

obexd[84170]: obexd/client/session.c:obc_session_unref() 0x55de7433e390: ref=3

obexd[84170]: Transfer(0x55de7433e520) Error: Precondition Failed