### PR TITLE
Revert "bluetooth.service: Set ConfigurationDirectoryMode"

### DIFF
--- a/src/bluetooth.service.in
+++ b/src/bluetooth.service.in
@@ -22,7 +22,6 @@ ProtectControlGroups=true
 StateDirectory=bluetooth
 StateDirectoryMode=0700
 ConfigurationDirectory=bluetooth
-ConfigurationDirectoryMode=0555
 
 # Execute Mappings
 MemoryDenyWriteExecute=true


### PR DESCRIPTION
This reverts commit 00cfb36e20e3c35db2150e7d0351ad7b8442e2d8.

This directory is owned by root and root can write to it regardless of file mode set.

Moreover, usually this directory is pre-created on system before service starts which makes this setting no-op and print annoying warning on every startup:

'bluetooth.service: ConfigurationDirectory 'bluetooth' already exists
but the mode is different. (File system: 755 ConfigurationDirectoryMode: 555)'

As setting this doesn't serve any purpose it should be reverted.

cc @hadess @Vudentz 