### PR TITLE
monitor/att: split parsers for 0x21 and 0x23 in btmon

### DIFF
--- a/monitor/att.c
+++ b/monitor/att.c
@@ -5769,11 +5769,35 @@ static void att_handle_value_conf(const struct l2cap_frame *frame)
 {
 }
 
-static void att_multiple_vl_rsp(const struct l2cap_frame *frame)
+static void att_read_multiple_vl_rsp(const struct l2cap_frame *frame)
 {
 	struct l2cap_frame *f = (void *) frame;
 
-	while (frame->size) {
+	while (f->size) {
+		uint16_t len;
+
+		if (!l2cap_frame_get_le16(f, &len))
+			return;
+
+		print_field("Length: 0x%4.4x", len);
+
+		if (len > f->size) {
+			print_text(COLOR_ERROR, "invalid size");
+			return;
+		}
+
+		print_hex_field("Data", f->data, len);
+		
+		if (!l2cap_frame_pull(f, f, len))
+			return;
+	}
+}
+
+static void att_multiple_vl_ntf(const struct l2cap_frame *frame)
+{
+	struct l2cap_frame *f = (void *) frame;
+
+	while (f->size) {
 		uint16_t handle;
 		uint16_t len;
 
@@ -5787,7 +5811,8 @@ static void att_multiple_vl_rsp(const struct l2cap_frame *frame)
 
 		print_notify(frame, handle, len);
 
-		l2cap_frame_pull(f, f, len);
+		if (!l2cap_frame_pull(f, f, len))
+			return;
 	}
 }
 
@@ -5878,9 +5903,9 @@ static const struct att_opcode_data att_opcode_table[] = {
 	{ 0x20, "Read Multiple Request Variable Length",
 			att_read_multiple_req, 4, false },
 	{ 0x21, "Read Multiple Response Variable Length",
-			att_multiple_vl_rsp, 4, false },
+			att_read_multiple_vl_rsp, 2, false },
 	{ 0x23, "Handle Multiple Value Notification",
-			att_multiple_vl_rsp, 4, false },
+			att_multiple_vl_ntf, 4, false },
 	{ 0x52, "Write Command",
 			att_write_command, 2, false },
 	{ 0xd2, "Signed Write Command", att_signed_write_command, 14, false },


### PR DESCRIPTION
ATT Read Multiple Variable Length Response (0x21) and Handle Multiple Value Notification (0x23)
use different tuple formats as defined in the Bluetooth Core Specification:

- 0x21: Length | Value
- 0x23: Handle | Length | Value

btmon incorrectly used a shared decoder for both opcodes, causing 0x21 PDUs to be misparsed
as if they contained a Handle field. This leads to corrupted output and "invalid size" errors
when decoding captures containing 0x21 responses.

Fix this by:
- Splitting decoding into separate handlers per opcode
  - att_read_multiple_vl_rsp() for 0x21
  - att_multiple_vl_ntf() for 0x23
- Updating opcode table entries accordingly
- Adjusting minimum size for 0x21 from 4 → 2 bytes
- Adding proper bounds checking in variable-length parsing

This ensures each opcode is decoded according to its corresponding ATT PDU format in the
Bluetooth Core Specification:

- Vol 3, Part F, §3.4.4.12 (0x21)
- Vol 3, Part F, §3.4.7.4 (0x23)

This change is limited to btmon (monitor decoding) and does not affect bluetoothd,
kernel, or controller behavior.