### PR TITLE
src/shared: parse local & remote data and expose CS ranging data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -249,7 +249,8 @@ shared_sources = src/shared/io.h src/shared/timeout.h \
 			src/shared/asha.h src/shared/asha.c \
 			src/shared/battery.h src/shared/battery.c \
 			src/shared/uinput.h src/shared/uinput.c \
-			src/shared/rap.h src/shared/rap.c
+			src/shared/rap.h src/shared/rap.c \
+			src/shared/bcs_util.h src/shared/bcs_util.c
 
 
 if READLINE

--- a/src/shared/bcs_util.c
+++ b/src/shared/bcs_util.c
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * BlueZ - Bluetooth protocol stack for Linux
+ *
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#define _GNU_SOURCE
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <sys/uio.h>
+
+#include "bluetooth/bluetooth.h"
+#include "src/shared/util.h"
+#include "src/shared/rap.h"
+#include "src/shared/bcs_util.h"
+
+static void step_data_free_inner(cs_step_data *steps, int64_t count)
+{
+	int64_t i;
+	cs_mode_two_data *m2;
+
+	if (!steps)
+		return;
+
+	for (i = 0; i < count; i++) {
+		uint8_t mode = steps[i].step_mode & 0x03;
+
+		if (mode == 0x02) /* CS_MODE_TWO */
+			m2 = &steps[i].step_mode_data.mode_two_data;
+		else if (mode == 0x03) /* CS_MODE_THREE */
+			m2 = &steps[i].step_mode_data.mode_three_data.mode_two_data;
+		else
+			continue;
+
+		free(m2->tone_pct_iq_samples);
+		m2->tone_pct_iq_samples = NULL;
+		free(m2->tone_quality_indicators);
+		m2->tone_quality_indicators = NULL;
+	}
+}
+
+static void copy_cs_step_mode_zero_data(cs_mode_zero_data *dst,
+					const cs_mode_zero_data *src)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint32_t tmp32;
+
+	temp_iov.iov_base = malloc(16);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov, (uint8_t)src->packet_quality)  ||
+	    !util_iov_push_u8(&temp_iov, (uint8_t)src->packet_rssi_dbm) ||
+	    !util_iov_push_u8(&temp_iov, (uint8_t)src->packet_antenna)  ||
+	    !util_iov_push_le32(&temp_iov,
+				(uint32_t)src->initiator_measured_freq_offset))
+		goto done;
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_quality);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_rssi_dbm);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_antenna);
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->initiator_measured_freq_offset = (int32_t)tmp32;
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void copy_cs_step_mode_one_data(cs_mode_one_data *dst,
+				       const cs_mode_one_data *src)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint32_t tmp32;
+
+	temp_iov.iov_base = malloc(64);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov, (uint8_t)src->packet_quality)  ||
+	    !util_iov_push_u8(&temp_iov, (uint8_t)src->packet_nadm)      ||
+	    !util_iov_push_u8(&temp_iov, (uint8_t)src->packet_rssi_dbm)  ||
+	    !util_iov_push_le32(&temp_iov,
+				(uint32_t)src->rtt_toa_tod_data.toa_tod_initiator) ||
+	    !util_iov_push_u8(&temp_iov, (uint8_t)src->packet_antenna)   ||
+	    !util_iov_push_le32(&temp_iov, (uint32_t)src->packet_pct1.i_sample) ||
+	    !util_iov_push_le32(&temp_iov, (uint32_t)src->packet_pct1.q_sample) ||
+	    !util_iov_push_le32(&temp_iov, (uint32_t)src->packet_pct2.i_sample) ||
+	    !util_iov_push_le32(&temp_iov, (uint32_t)src->packet_pct2.q_sample))
+		goto done;
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_quality);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_nadm);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_rssi_dbm);
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->rtt_toa_tod_data.toa_tod_initiator = (int32_t)tmp32;
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_antenna);
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->packet_pct1.i_sample = (int32_t)tmp32;
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->packet_pct1.q_sample = (int32_t)tmp32;
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->packet_pct2.i_sample = (int32_t)tmp32;
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->packet_pct2.q_sample = (int32_t)tmp32;
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void copy_cs_step_mode_two_data(cs_mode_two_data *dst,
+				       const cs_mode_two_data *src)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint32_t tmp32;
+
+	temp_iov.iov_base = malloc(16);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov,
+			      (uint8_t)src->antenna_permutation_index) ||
+	    !util_iov_push_le32(&temp_iov,
+				(uint32_t)src->tone_pct_iq_sample_size)    ||
+	    !util_iov_push_le32(&temp_iov,
+				(uint32_t)src->tone_quality_indicators_size))
+		goto done;
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->antenna_permutation_index);
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->tone_pct_iq_sample_size = (int32_t)tmp32;
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->tone_quality_indicators_size = (int32_t)tmp32;
+
+	if (src->tone_pct_iq_samples && dst->tone_pct_iq_sample_size > 0) {
+		dst->tone_pct_iq_samples = calloc(dst->tone_pct_iq_sample_size,
+						  sizeof(cs_pct_iq_sample));
+		if (dst->tone_pct_iq_samples)
+			memcpy(dst->tone_pct_iq_samples, src->tone_pct_iq_samples,
+			       dst->tone_pct_iq_sample_size *
+			       sizeof(cs_pct_iq_sample));
+	}
+
+	if (src->tone_quality_indicators && dst->tone_quality_indicators_size > 0) {
+		dst->tone_quality_indicators =
+			calloc(dst->tone_quality_indicators_size, 1);
+		if (dst->tone_quality_indicators)
+			memcpy(dst->tone_quality_indicators,
+			       src->tone_quality_indicators,
+			       dst->tone_quality_indicators_size);
+	}
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void copy_cs_step_mode_three_data(cs_mode_three_data *dst,
+					 const cs_mode_three_data *src)
+{
+	copy_cs_step_mode_one_data(&dst->mode_one_data, &src->mode_one_data);
+	copy_cs_step_mode_two_data(&dst->mode_two_data, &src->mode_two_data);
+}
+
+static void copy_cs_step_data(cs_step_data *dst, const cs_step_data *src)
+{
+	dst->step_channel = src->step_channel;
+	dst->step_mode    = src->step_mode;
+
+	switch (src->step_mode & 0x03) {
+	case CS_MODE_ZERO:
+		copy_cs_step_mode_zero_data(&dst->step_mode_data.mode_zero_data,
+					    &src->step_mode_data.mode_zero_data);
+		break;
+	case CS_MODE_ONE:
+		copy_cs_step_mode_one_data(&dst->step_mode_data.mode_one_data,
+					   &src->step_mode_data.mode_one_data);
+		break;
+	case CS_MODE_TWO:
+		copy_cs_step_mode_two_data(&dst->step_mode_data.mode_two_data,
+					   &src->step_mode_data.mode_two_data);
+		break;
+	case CS_MODE_THREE:
+		copy_cs_step_mode_three_data(
+					&dst->step_mode_data.mode_three_data,
+					&src->step_mode_data.mode_three_data);
+		break;
+	default:
+		break;
+	}
+}
+
+cs_subevent_result_data *bcs_subevent_result_data_new(
+				int32_t start_acl_conn_event_counter,
+				int32_t frequency_compensation,
+				int8_t reference_power_level_dbm,
+				int8_t num_antenna_paths,
+				int8_t subevent_abort_reason,
+				int64_t timestamp_nanos,
+				const cs_step_data *steps,
+				int64_t num_steps)
+{
+	cs_subevent_result_data *subevent;
+
+	subevent = calloc(1, sizeof(*subevent));
+	if (!subevent)
+		return NULL;
+
+	subevent->start_acl_conn_event_counter = start_acl_conn_event_counter;
+	subevent->frequency_compensation       = frequency_compensation;
+	subevent->reference_power_level_dbm    = reference_power_level_dbm;
+	subevent->num_antenna_paths            = num_antenna_paths;
+	subevent->subevent_abort_reason        = subevent_abort_reason;
+	subevent->timestamp_nanos              = timestamp_nanos;
+
+	if (steps && num_steps > 0) {
+		int64_t i;
+
+		subevent->step_data = calloc(num_steps, sizeof(cs_step_data));
+		if (!subevent->step_data) {
+			free(subevent);
+			return NULL;
+		}
+		for (i = 0; i < num_steps; i++)
+			copy_cs_step_data(&subevent->step_data[i], &steps[i]);
+		subevent->step_data_size = num_steps;
+	}
+
+	return subevent;
+}
+
+void bcs_subevent_result_data_free(cs_subevent_result_data *subevent)
+{
+	if (!subevent)
+		return;
+
+	step_data_free_inner(subevent->step_data, subevent->step_data_size);
+	free(subevent->step_data);
+	free(subevent);
+}
+
+bcs_procedure_data *bcs_procedure_data_new(void)
+{
+	return calloc(1, sizeof(bcs_procedure_data));
+}
+
+void bcs_procedure_data_free(bcs_procedure_data *proc)
+{
+	int32_t i;
+
+	if (!proc)
+		return;
+
+	for (i = 0; i < proc->initiator_subevent_result_data_size; i++) {
+		step_data_free_inner(
+			proc->initiator_subevent_result_data[i].step_data,
+			proc->initiator_subevent_result_data[i].step_data_size);
+		free(proc->initiator_subevent_result_data[i].step_data);
+	}
+	free(proc->initiator_subevent_result_data);
+
+	for (i = 0; i < proc->reflector_subevent_result_data_size; i++) {
+		step_data_free_inner(
+			proc->reflector_subevent_result_data[i].step_data,
+			proc->reflector_subevent_result_data[i].step_data_size);
+		free(proc->reflector_subevent_result_data[i].step_data);
+	}
+	free(proc->reflector_subevent_result_data);
+
+	free(proc);
+}
+
+void bcs_procedure_data_clear(bcs_procedure_data *proc)
+{
+	int32_t i;
+
+	if (!proc)
+		return;
+
+	for (i = 0; i < proc->initiator_subevent_result_data_size; i++) {
+		step_data_free_inner(
+			proc->initiator_subevent_result_data[i].step_data,
+			proc->initiator_subevent_result_data[i].step_data_size);
+		free(proc->initiator_subevent_result_data[i].step_data);
+	}
+	free(proc->initiator_subevent_result_data);
+	proc->initiator_subevent_result_data      = NULL;
+	proc->initiator_subevent_result_data_size = 0;
+
+	for (i = 0; i < proc->reflector_subevent_result_data_size; i++) {
+		step_data_free_inner(
+			proc->reflector_subevent_result_data[i].step_data,
+			proc->reflector_subevent_result_data[i].step_data_size);
+		free(proc->reflector_subevent_result_data[i].step_data);
+	}
+	free(proc->reflector_subevent_result_data);
+	proc->reflector_subevent_result_data      = NULL;
+	proc->reflector_subevent_result_data_size = 0;
+}
+
+bool bcs_procedure_data_add_initiator_subevent(bcs_procedure_data *proc,
+					cs_subevent_result_data *subevent)
+{
+	cs_subevent_result_data *arr;
+	int32_t new_count;
+
+	if (!proc || !subevent)
+		return false;
+
+	new_count = proc->initiator_subevent_result_data_size + 1;
+	arr = realloc(proc->initiator_subevent_result_data,
+					new_count * sizeof(*arr));
+	if (!arr)
+		return false;
+
+	arr[new_count - 1].start_acl_conn_event_counter =
+					subevent->start_acl_conn_event_counter;
+	arr[new_count - 1].frequency_compensation  = subevent->frequency_compensation;
+	arr[new_count - 1].reference_power_level_dbm = subevent->reference_power_level_dbm;
+	arr[new_count - 1].num_antenna_paths       = subevent->num_antenna_paths;
+	arr[new_count - 1].subevent_abort_reason   = subevent->subevent_abort_reason;
+	arr[new_count - 1].step_data_size          = subevent->step_data_size;
+	arr[new_count - 1].step_data               = subevent->step_data;
+	arr[new_count - 1].timestamp_nanos         = subevent->timestamp_nanos;
+	free(subevent);
+
+	proc->initiator_subevent_result_data      = arr;
+	proc->initiator_subevent_result_data_size = new_count;
+
+	return true;
+}
+
+bool bcs_procedure_data_add_reflector_subevent(bcs_procedure_data *proc,
+					cs_subevent_result_data *subevent)
+{
+	cs_subevent_result_data *arr;
+	int32_t new_count;
+
+	if (!proc || !subevent)
+		return false;
+
+	new_count = proc->reflector_subevent_result_data_size + 1;
+	arr = realloc(proc->reflector_subevent_result_data,
+					new_count * sizeof(*arr));
+	if (!arr)
+		return false;
+
+	arr[new_count - 1].start_acl_conn_event_counter =
+					subevent->start_acl_conn_event_counter;
+	arr[new_count - 1].frequency_compensation  = subevent->frequency_compensation;
+	arr[new_count - 1].reference_power_level_dbm = subevent->reference_power_level_dbm;
+	arr[new_count - 1].num_antenna_paths       = subevent->num_antenna_paths;
+	arr[new_count - 1].subevent_abort_reason   = subevent->subevent_abort_reason;
+	arr[new_count - 1].step_data_size          = subevent->step_data_size;
+	arr[new_count - 1].step_data               = subevent->step_data;
+	arr[new_count - 1].timestamp_nanos         = subevent->timestamp_nanos;
+	free(subevent);
+
+	proc->reflector_subevent_result_data      = arr;
+	proc->reflector_subevent_result_data_size = new_count;
+
+	return true;
+}
+
+void bcs_procedure_data_set_config(bcs_procedure_data *proc,
+					const cs_config_param *config)
+{
+	if (!proc || !config)
+		return;
+
+	proc->cs_config_param = *config;
+}
+
+void bcs_procedure_data_set_procedure_config(bcs_procedure_data *proc,
+					const cs_procedure_enable_config *config)
+{
+	if (!proc || !config)
+		return;
+
+	proc->procedure_enable_config = *config;
+}
+
+static void hci_step_to_bcs_mode0_step(const struct cs_mode_zero_data *src,
+					cs_mode_zero_data *dst)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint32_t tmp32;
+
+	temp_iov.iov_base = malloc(16);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov, src->packet_quality) ||
+	    !util_iov_push_u8(&temp_iov, src->packet_rssi_dbm) ||
+	    !util_iov_push_u8(&temp_iov, src->packet_ant) ||
+	    !util_iov_push_le32(&temp_iov, src->init_measured_freq_offset))
+		goto done;
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_quality);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_rssi_dbm);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_antenna);
+	if (util_iov_pull_le32(&pull_iov, &tmp32))
+		dst->initiator_measured_freq_offset = (int32_t)tmp32;
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void hci_step_to_bcs_mode1_step(const struct cs_mode_one_data *src,
+					cs_mode_one_data *dst,
+					uint8_t rtt_type)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint16_t tmp16;
+	bool include_pct = (rtt_type != 0x00);
+
+	temp_iov.iov_base = malloc(64);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov, src->packet_quality) ||
+	    !util_iov_push_u8(&temp_iov, src->packet_nadm)     ||
+	    !util_iov_push_u8(&temp_iov, src->packet_rssi_dbm) ||
+	    !util_iov_push_le16(&temp_iov, (uint16_t)src->toa_tod_init) ||
+	    !util_iov_push_u8(&temp_iov, src->packet_ant))
+		goto done;
+
+	if (include_pct) {
+		if (!util_iov_push_le16(&temp_iov,
+					(uint16_t)src->packet_pct1.i_sample) ||
+		    !util_iov_push_le16(&temp_iov,
+					(uint16_t)src->packet_pct1.q_sample) ||
+		    !util_iov_push_le16(&temp_iov,
+					(uint16_t)src->packet_pct2.i_sample) ||
+		    !util_iov_push_le16(&temp_iov,
+					(uint16_t)src->packet_pct2.q_sample))
+			goto done;
+	}
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_quality);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_nadm);
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_rssi_dbm);
+
+	if (util_iov_pull_le16(&pull_iov, &tmp16))
+		dst->rtt_toa_tod_data.toa_tod_initiator = (int16_t)tmp16;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->packet_antenna);
+
+	if (include_pct) {
+		if (util_iov_pull_le16(&pull_iov, &tmp16))
+			dst->packet_pct1.i_sample = (int16_t)tmp16;
+		if (util_iov_pull_le16(&pull_iov, &tmp16))
+			dst->packet_pct1.q_sample = (int16_t)tmp16;
+		if (util_iov_pull_le16(&pull_iov, &tmp16))
+			dst->packet_pct2.i_sample = (int16_t)tmp16;
+		if (util_iov_pull_le16(&pull_iov, &tmp16))
+			dst->packet_pct2.q_sample = (int16_t)tmp16;
+	}
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void hci_step_to_bcs_mode2_step(const struct cs_mode_two_data *src,
+					cs_mode_two_data *dst,
+					uint8_t num_antenna_paths)
+{
+	struct iovec temp_iov = { 0 };
+	struct iovec pull_iov;
+	uint16_t tmp16;
+	int k;
+	uint8_t num_paths = (num_antenna_paths + 1) < 5 ?
+		(num_antenna_paths + 1) : 5;
+
+	temp_iov.iov_base = malloc(128);
+	if (!temp_iov.iov_base)
+		return;
+	temp_iov.iov_len = 0;
+
+	if (!util_iov_push_u8(&temp_iov, src->ant_perm_index))
+		goto done;
+
+	for (k = 0; k < num_paths; k++) {
+		if (!util_iov_push_le16(&temp_iov,
+					(uint16_t)src->tone_pct[k].i_sample) ||
+		    !util_iov_push_le16(&temp_iov,
+					(uint16_t)src->tone_pct[k].q_sample) ||
+		    !util_iov_push_u8(&temp_iov, src->tone_quality_indicator[k]))
+			goto done;
+	}
+
+	pull_iov.iov_base = temp_iov.iov_base;
+	pull_iov.iov_len  = temp_iov.iov_len;
+
+	util_iov_pull_u8(&pull_iov, (uint8_t *)&dst->antenna_permutation_index);
+
+	dst->tone_pct_iq_samples =
+		calloc(num_paths, sizeof(cs_pct_iq_sample));
+	dst->tone_quality_indicators = calloc(num_paths, 1);
+
+	if (dst->tone_pct_iq_samples && dst->tone_quality_indicators) {
+		for (k = 0; k < num_paths; k++) {
+			if (util_iov_pull_le16(&pull_iov, &tmp16))
+				dst->tone_pct_iq_samples[k].i_sample =
+					(int16_t)tmp16;
+			if (util_iov_pull_le16(&pull_iov, &tmp16))
+				dst->tone_pct_iq_samples[k].q_sample =
+					(int16_t)tmp16;
+			util_iov_pull_u8(&pull_iov,
+					 &dst->tone_quality_indicators[k]);
+		}
+		dst->tone_pct_iq_sample_size      = num_paths;
+		dst->tone_quality_indicators_size = num_paths;
+	}
+
+done:
+	free(temp_iov.iov_base);
+}
+
+static void hci_step_to_bcs_mode3_step(const struct cs_mode_three_data *src,
+					cs_mode_three_data *dst,
+					uint8_t rtt_type,
+					uint8_t num_antenna_paths)
+{
+	hci_step_to_bcs_mode1_step(&src->mode_one_data, &dst->mode_one_data,
+				   rtt_type);
+	hci_step_to_bcs_mode2_step(&src->mode_two_data, &dst->mode_two_data,
+				   num_antenna_paths);
+}
+
+void hci_step_to_bcs_step(const struct cs_step_data *src,
+			   cs_step_data *dst,
+			   uint8_t rtt_type,
+			   uint8_t num_antenna_paths)
+{
+	dst->step_mode    = src->step_mode;
+	dst->step_channel = src->step_chnl;
+
+	switch (src->step_mode & 0x03) {
+	case CS_MODE_ZERO:
+		hci_step_to_bcs_mode0_step(&src->step_mode_data.mode_zero_data,
+					   &dst->step_mode_data.mode_zero_data);
+		break;
+	case CS_MODE_ONE:
+		hci_step_to_bcs_mode1_step(&src->step_mode_data.mode_one_data,
+					   &dst->step_mode_data.mode_one_data,
+					   rtt_type);
+		break;
+	case CS_MODE_TWO:
+		hci_step_to_bcs_mode2_step(&src->step_mode_data.mode_two_data,
+					   &dst->step_mode_data.mode_two_data,
+					   num_antenna_paths);
+		break;
+	case CS_MODE_THREE:
+		hci_step_to_bcs_mode3_step(&src->step_mode_data.mode_three_data,
+					   &dst->step_mode_data.mode_three_data,
+					   rtt_type, num_antenna_paths);
+		break;
+	default:
+		break;
+	}
+}

--- a/src/shared/bcs_util.h
+++ b/src/shared/bcs_util.h
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * BlueZ - Bluetooth protocol stack for Linux
+ *
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+ #include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#define CS_MODE_ZERO_WIRE_INIT_SIZE 7
+#define CS_MODE_ZERO_WIRE_REF_SIZE 3
+#define CS_MODE_ONE_WIRE_SIZE_MIN 6
+#define CS_MODE_ONE_WIRE_SIZE_MAX 12
+
+struct cs_step_data;
+
+typedef struct {
+	int8_t  mode_type;
+	int8_t  sub_mode_type;
+	int32_t rtt_type;
+	uint8_t channel_map[10];
+	int32_t min_main_mode_steps;
+	int32_t max_main_mode_steps;
+	int8_t  main_mode_repetition;
+	int8_t  mode_0_steps;
+	int32_t role;
+	int8_t  cs_sync_phy_type;
+	int8_t  channel_selection_type;
+	int8_t  ch3c_shape_type;
+	int8_t  ch3c_jump;
+	int32_t channel_map_repetition;
+	int32_t t_ip1_time_us;
+	int32_t t_ip2_time_us;
+	int32_t t_fcs_time_us;
+	int8_t  t_pm_time_us;
+	int8_t  t_sw_time_us_supported_by_local;
+	int8_t  t_sw_time_us_supported_by_remote;
+	int32_t ble_conn_interval;
+} cs_config_param;
+
+typedef struct {
+	int8_t  tone_antenna_config_selection;
+	int32_t subevent_len_us;
+	int8_t  subevents_per_event;
+	int32_t subevent_interval;
+	int32_t event_interval;
+	int32_t procedure_interval;
+	int32_t procedure_count;
+	int32_t max_procedure_len;
+} cs_procedure_enable_config;
+
+typedef struct {
+	int32_t i_sample;
+	int32_t q_sample;
+} cs_pct_iq_sample;
+
+typedef union {
+	int32_t toa_tod_initiator;
+	int32_t tod_toa_reflector;
+} cs_rtt_toa_tod_data;
+
+typedef struct {
+	int8_t  packet_quality;
+	int8_t  packet_rssi_dbm;
+	int8_t  packet_antenna;
+	int32_t initiator_measured_freq_offset;
+} cs_mode_zero_data;
+
+typedef struct {
+	int8_t               packet_quality;
+	int8_t               packet_nadm;
+	int8_t               packet_rssi_dbm;
+	cs_rtt_toa_tod_data  rtt_toa_tod_data;
+	int8_t               packet_antenna;
+	cs_pct_iq_sample     packet_pct1;
+	cs_pct_iq_sample     packet_pct2;
+} cs_mode_one_data;
+
+typedef struct {
+	int8_t            antenna_permutation_index;
+	int32_t           tone_pct_iq_sample_size;
+	cs_pct_iq_sample *tone_pct_iq_samples;
+	int32_t           tone_quality_indicators_size;
+	uint8_t          *tone_quality_indicators;
+} cs_mode_two_data;
+
+typedef struct {
+	cs_mode_one_data mode_one_data;
+	cs_mode_two_data mode_two_data;
+} cs_mode_three_data;
+
+typedef union {
+	cs_mode_zero_data  mode_zero_data;
+	cs_mode_one_data   mode_one_data;
+	cs_mode_two_data   mode_two_data;
+	cs_mode_three_data mode_three_data;
+} cs_mode_data;
+
+typedef struct {
+	int8_t       step_channel;
+	int8_t       step_mode;
+	cs_mode_data step_mode_data;
+} cs_step_data;
+
+typedef struct {
+	int32_t        start_acl_conn_event_counter;
+	int32_t        frequency_compensation;
+	int8_t         reference_power_level_dbm;
+	int8_t         num_antenna_paths;
+	int8_t         subevent_abort_reason;
+	int64_t        step_data_size;
+	cs_step_data  *step_data;
+	int64_t        timestamp_nanos;
+} cs_subevent_result_data;
+
+typedef struct bcs_procedure_data {
+	int32_t                    procedure_counter;
+	int32_t                    procedure_sequence;
+	int8_t                     initiator_selected_tx_power;
+	int8_t                     reflector_selected_tx_power;
+	int32_t                    initiator_subevent_result_data_size;
+	cs_subevent_result_data   *initiator_subevent_result_data;
+	int8_t                     initiator_procedure_abort_reason;
+	int32_t                    reflector_subevent_result_data_size;
+	cs_subevent_result_data   *reflector_subevent_result_data;
+	int8_t                     reflector_procedure_abort_reason;
+	cs_procedure_enable_config procedure_enable_config;
+	cs_config_param            cs_config_param;
+} bcs_procedure_data;
+
+/* cs_subevent_result_data lifecycle */
+cs_subevent_result_data *bcs_subevent_result_data_new(
+				int32_t start_acl_conn_event_counter,
+				int32_t frequency_compensation,
+				int8_t reference_power_level_dbm,
+				int8_t num_antenna_paths,
+				int8_t subevent_abort_reason,
+				int64_t timestamp_nanos,
+				const cs_step_data *steps,
+				int64_t num_steps);
+
+void bcs_subevent_result_data_free(cs_subevent_result_data *subevent);
+
+/* bcs_procedure_data lifecycle */
+bcs_procedure_data *bcs_procedure_data_new(void);
+void bcs_procedure_data_free(bcs_procedure_data *proc);
+void bcs_procedure_data_clear(bcs_procedure_data *proc);
+
+bool bcs_procedure_data_add_initiator_subevent(bcs_procedure_data *proc,
+					cs_subevent_result_data *subevent);
+bool bcs_procedure_data_add_reflector_subevent(bcs_procedure_data *proc,
+					cs_subevent_result_data *subevent);
+
+/* Set nested config fields */
+void bcs_procedure_data_set_config(bcs_procedure_data *proc,
+					const cs_config_param *config);
+void bcs_procedure_data_set_procedure_config(bcs_procedure_data *proc,
+					const cs_procedure_enable_config *config);
+
+void hci_step_to_bcs_step(const struct cs_step_data *src,
+			   cs_step_data *dst,
+			   uint8_t rtt_type,
+			   uint8_t num_antenna_paths);

--- a/src/shared/rap.c
+++ b/src/shared/rap.c
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <errno.h>
+#include <time.h>
 
 #include "bluetooth/bluetooth.h"
 #include "bluetooth/hci.h"
@@ -25,9 +26,13 @@
 #include "src/shared/gatt-server.h"
 #include "src/shared/gatt-client.h"
 #include "src/shared/rap.h"
+#include "src/shared/bcs_util.h"
 
 #define DBG(_rap, fmt, ...) \
 	rap_debug(_rap, "%s:%s() " fmt, __FILE__, __func__, ##__VA_ARGS__)
+
+#define SIGN_EXTEND_TO_16(val, bits) \
+	((int16_t)(((val) ^ (1U << ((bits)-1))) - (1U << ((bits)-1))))
 
 #define RAS_UUID16			0x185B
 
@@ -134,6 +139,28 @@ static inline void ranging_header_set_pct_format(struct ranging_header *hdr,
 				((format & 0x03) << 6);
 }
 
+static inline uint8_t ranging_header_get_antenna_mask(
+					const struct ranging_header *hdr)
+{
+	if (!hdr)
+		return 0;
+
+	return hdr->antenna_pct & 0x0F;
+}
+
+static inline uint8_t antenna_mask_count_paths(uint8_t antenna_mask)
+{
+	uint8_t count = 0;
+	uint8_t i;
+
+	for (i = 0; i < 4; i++) {
+		if (antenna_mask & (1u << i))
+			count++;
+	}
+
+	return count;
+}
+
 struct ras_subevent_header {
 	uint16_t start_acl_conn_event;
 	uint16_t frequency_compensation;
@@ -149,8 +176,20 @@ struct ras_subevent_header {
 #define RAS_DONE_STATUS_PACK(ranging, subevent) \
 	((uint8_t)(((ranging) & 0x0F) | (((subevent) & 0x0F) << 4)))
 
+#define RAS_DONE_STATUS_UNPACK_RANGING(packed) \
+	((uint8_t)((packed) & 0x0F))
+
+#define RAS_DONE_STATUS_UNPACK_SUBEVENT(packed) \
+	((uint8_t)(((packed) >> 4) & 0x0F))
+
 #define RAS_ABORT_REASON_PACK(ranging, subevent) \
 	((uint8_t)(((ranging) & 0x0F) | (((subevent) & 0x0F) << 4)))
+
+#define RAS_ABORT_REASON_UNPACK_RANGING(packed) \
+	((uint8_t)((packed) & 0x0F))
+
+#define RAS_ABORT_REASON_UNPACK_SUBEVENT(packed) \
+	((uint8_t)(((packed) >> 4) & 0x0F))
 
 struct ras_subevent {
 	struct ras_subevent_header subevent_header;
@@ -206,6 +245,23 @@ struct cstracker {
 	uint16_t last_start_acl_conn_evt_counter;
 	uint16_t last_freq_comp;
 	int8_t last_ref_pwr_lvl;
+
+	/* Client/initiator parameters*/
+	struct ranging_header   ranging_header_;
+	struct iovec segment_data;
+	bcs_procedure_data bcs_proc_data;
+
+	/* Timestamp tracking for procedure duration */
+	long proc_start_timestamp_nanos;
+	uint8_t procedure_sequence_after_enable;
+
+	/* Local-side procedure completion status */
+	enum cs_procedure_done_status local_proc_done_status;
+	bool local_has_complete_subevent;
+
+	/* Remote-side procedure completion status */
+	enum cs_procedure_done_status remote_proc_done_status;
+	bool remote_has_complete_subevent;
 };
 
 /* Ranging Service context */
@@ -229,6 +285,11 @@ struct ras {
 	/* CCC state tracking for mutual exclusivity */
 	uint16_t realtime_ccc_value;
 	uint16_t ondemand_ccc_value;
+
+	/* Client-side cached handles */
+	uint16_t features_handle;
+	bool features_read_pending;  /* true if a read is in-flight */
+	bool features_read_success;  /* true once features have been read */
 };
 
 struct bt_rap_db {
@@ -253,7 +314,13 @@ struct bt_rap {
 	bt_rap_destroy_func_t debug_destroy;
 	void *debug_data;
 	void *user_data;
+
+	bt_rap_procedure_data_func_t procedure_data_cb;
+	bt_rap_destroy_func_t procedure_data_destroy;
+	void *procedure_data_user_data;
+
 	struct cstracker *resptracker;
+	struct cstracker *reqtracker;
 };
 
 static struct queue *rap_db;
@@ -272,6 +339,28 @@ struct bt_rap_ready {
 	bt_rap_ready_func_t func;
 	bt_rap_destroy_func_t destroy;
 	void *data;
+};
+
+typedef void (*rap_notify_t)(struct bt_rap *rap, uint16_t value_handle,
+			const uint8_t *value, uint16_t length,
+			void *user_data);
+
+struct bt_rap_notify {
+	unsigned int id;
+	struct bt_rap *rap;
+	rap_notify_t func;
+	void *user_data;
+};
+
+typedef void (*rap_func_t)(struct bt_rap *rap, bool success,
+			uint8_t att_ecode, const uint8_t *value,
+			uint16_t length, void *user_data);
+
+struct bt_rap_pending {
+	unsigned int id;
+	struct bt_rap *rap;
+	rap_func_t func;
+	void *userdata;
 };
 
 uint16_t default_ras_mtu = 247; /*Section 3.1.2 of RAP 1.0*/
@@ -538,8 +627,32 @@ static void rap_free(void *data)
 	rap_db_free(rap->rrapdb);
 
 	if (rap->resptracker) {
+		/* Free current_proc if it exists */
+		if (rap->resptracker->current_proc) {
+			cs_procedure_data_destroy(
+				rap->resptracker->current_proc);
+			rap->resptracker->current_proc = NULL;
+		}
+		/* Free segment_data if allocated */
+		free(rap->resptracker->segment_data.iov_base);
 		free(rap->resptracker);
 		rap->resptracker = NULL;
+	}
+
+	if (rap->reqtracker) {
+		/* Free current_proc if it exists */
+		if (rap->reqtracker->current_proc) {
+			cs_procedure_data_destroy(
+				rap->reqtracker->current_proc);
+			rap->reqtracker->current_proc = NULL;
+		}
+
+		bcs_procedure_data_clear(&rap->reqtracker->bcs_proc_data);
+
+		/* Free segment_data if allocated */
+		free(rap->reqtracker->segment_data.iov_base);
+		free(rap->reqtracker);
+		rap->reqtracker = NULL;
 	}
 
 	queue_destroy(rap->notify, free);
@@ -627,6 +740,113 @@ bool bt_rap_set_debug(struct bt_rap *rap, bt_rap_debug_func_t func,
 	return true;
 }
 
+bool bt_rap_set_procedure_data_cb(struct bt_rap *rap,
+				  bt_rap_procedure_data_func_t cb,
+				  void *user_data,
+				  bt_rap_destroy_func_t destroy)
+{
+	if (!rap)
+		return false;
+
+	if (rap->procedure_data_destroy)
+		rap->procedure_data_destroy(rap->procedure_data_user_data);
+
+	rap->procedure_data_cb      = cb;
+	rap->procedure_data_destroy = destroy;
+	rap->procedure_data_user_data = user_data;
+
+	return true;
+}
+static int64_t get_time_nanos(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+	return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+static void write_procedure_data_to_bcs_algo(struct bt_rap *rap,
+					     bcs_procedure_data *bcs,
+					     enum cs_role local_role)
+{
+	int32_t i, j;
+
+	if (!rap || !bcs)
+		return;
+
+	DBG(rap, "procedure_counter=%u sequence=%d role=%s "
+	    "init_tx_pwr=%d refl_tx_pwr=%d "
+	    "init_abort=%d refl_abort=%d "
+	    "init_subevents=%d refl_subevents=%d",
+	    bcs->procedure_counter,
+	    bcs->procedure_sequence,
+	    local_role == CS_ROLE_INITIATOR ? "INITIATOR" : "REFLECTOR",
+	    bcs->initiator_selected_tx_power,
+	    bcs->reflector_selected_tx_power,
+	    bcs->initiator_procedure_abort_reason,
+	    bcs->reflector_procedure_abort_reason,
+	    bcs->initiator_subevent_result_data_size,
+	    bcs->reflector_subevent_result_data_size);
+
+	if (rap->reqtracker && rap->reqtracker->proc_start_timestamp_nanos) {
+		int64_t elapsed_nanos = get_time_nanos() -
+				rap->reqtracker->proc_start_timestamp_nanos;
+
+		DBG(rap, "Procedure elapsed time: %lld nanos",
+		    (long long)elapsed_nanos);
+
+		if (bcs->initiator_subevent_result_data_size > 0)
+			bcs->initiator_subevent_result_data[0].timestamp_nanos =
+								elapsed_nanos;
+		if (bcs->reflector_subevent_result_data_size > 0)
+			bcs->reflector_subevent_result_data[0].timestamp_nanos =
+								elapsed_nanos;
+	}
+
+	/* Deliver to upper-layer BCS distance algorithm */
+	if (rap->procedure_data_cb)
+		rap->procedure_data_cb(rap, bcs,
+				       rap->procedure_data_user_data);
+
+	bcs_procedure_data_clear(bcs);
+}
+static void check_cs_procedure_complete(struct bt_rap *rap,
+					 struct cstracker *reqtracker)
+{
+	bcs_procedure_data *bcs = &reqtracker->bcs_proc_data;
+
+	if (!rap->procedure_data_cb)
+		return;
+
+	if (reqtracker->local_proc_done_status !=
+	    CS_PROC_ALL_RESULTS_COMPLETE ||
+	    reqtracker->remote_proc_done_status !=
+	    CS_PROC_ALL_RESULTS_COMPLETE) {
+		DBG(rap, "Procedure not complete: local_status=%d"
+		    " remote_status=%d",
+		    reqtracker->local_proc_done_status,
+		    reqtracker->remote_proc_done_status);
+		return;
+	}
+
+	if (!reqtracker->local_has_complete_subevent &&
+	    !reqtracker->remote_has_complete_subevent) {
+		DBG(rap, "No complete subevent on either side");
+		return;
+	}
+
+	reqtracker->procedure_sequence_after_enable++;
+	bcs->procedure_sequence = reqtracker->procedure_sequence_after_enable;
+	write_procedure_data_to_bcs_algo(rap, bcs, reqtracker->role);
+
+	/* Reset remote status so a stale remote result can't re-trigger */
+	reqtracker->remote_proc_done_status = CS_PROC_PARTIAL_RESULTS;
+	reqtracker->remote_has_complete_subevent = false;
+	reqtracker->local_proc_done_status = CS_PROC_PARTIAL_RESULTS;
+	reqtracker->local_has_complete_subevent = false;
+}
+
+
 static void cs_tracker_init(struct cstracker *t)
 {
 	if (!t)
@@ -641,6 +861,27 @@ static void cs_tracker_init(struct cstracker *t)
 	t->last_start_acl_conn_evt_counter = 0;
 	t->last_freq_comp = 0;
 	t->last_ref_pwr_lvl = 0;
+
+	/* Initialize ranging header using helper functions */
+	memset(&t->ranging_header_, 0, sizeof(t->ranging_header_));
+	/* Initialize segment accumulator */
+	t->segment_data.iov_base = NULL;
+	t->segment_data.iov_len = 0;
+
+	/* Initialize timestamp tracking */
+	t->proc_start_timestamp_nanos = 0;
+
+	/* Initialize local procedure status to PARTIAL
+	 * until an HCI event updates it
+	 */
+	t->local_proc_done_status = CS_PROC_PARTIAL_RESULTS;
+	t->local_has_complete_subevent = false;
+
+	/* Initialize remote procedure status to PARTIAL
+	 * until RAS data updates it
+	 */
+	t->remote_proc_done_status = CS_PROC_PARTIAL_RESULTS;
+	t->remote_has_complete_subevent = false;
 }
 
 static void ras_features_read_cb(struct gatt_db_attribute *attrib,
@@ -1698,6 +1939,210 @@ static void form_ras_data_with_cs_subevent_result_cont(struct bt_rap *rap,
 		cont->step_data);
 }
 
+static void parse_cs_local_initiator_data(struct bt_rap *rap,
+					bool has_header_fields,
+					uint8_t config_id,
+					uint8_t num_ant_paths,
+					uint16_t proc_counter,
+					uint16_t start_acl_conn_evt_counter,
+					uint16_t freq_comp,
+					int8_t ref_pwr_lvl,
+					uint8_t proc_done_status,
+					uint8_t subevt_done_status,
+					uint8_t abort_reason,
+					uint8_t num_steps_reported,
+					const void *step_bytes)
+{
+	struct cstracker *reqtracker = rap->reqtracker;
+	bcs_procedure_data *bcs = &reqtracker->bcs_proc_data;
+	const struct cs_step_data *hci_steps = step_bytes;
+	size_t i;
+
+	bcs->initiator_selected_tx_power      = reqtracker->selected_tx_power;
+	bcs->initiator_procedure_abort_reason = abort_reason & 0x0F;
+
+	reqtracker->local_proc_done_status =
+		(enum cs_procedure_done_status)proc_done_status;
+	if (subevt_done_status == 0x00)
+		reqtracker->local_has_complete_subevent = true;
+
+	if (has_header_fields) {
+		cs_step_data *steps = NULL;
+		cs_subevent_result_data *subevent;
+
+		/* Reset per-procedure flags when a new
+		 * procedure counter arrives
+		 */
+		if (proc_counter != reqtracker->last_proc_counter) {
+			reqtracker->local_proc_done_status =
+				CS_PROC_PARTIAL_RESULTS;
+			reqtracker->local_has_complete_subevent = false;
+			/* Re-apply this event's status after the reset */
+			reqtracker->local_proc_done_status =
+				(enum cs_procedure_done_status)proc_done_status;
+			if (subevt_done_status == 0x00)
+				reqtracker->local_has_complete_subevent = true;
+		}
+
+		bcs->procedure_counter  = proc_counter;
+		reqtracker->last_proc_counter               = proc_counter;
+		reqtracker->last_start_acl_conn_evt_counter =
+					start_acl_conn_evt_counter;
+		reqtracker->last_freq_comp                  = freq_comp;
+		reqtracker->last_ref_pwr_lvl                = ref_pwr_lvl;
+
+		if (num_steps_reported > 0) {
+			steps = calloc(num_steps_reported,
+					sizeof(cs_step_data));
+			if (!steps)
+				return;
+
+			for (i = 0; i < num_steps_reported; i++)
+				hci_step_to_bcs_step(&hci_steps[i], &steps[i],
+							reqtracker->rtt_type,
+							num_ant_paths);
+		}
+
+		subevent = bcs_subevent_result_data_new(
+					start_acl_conn_evt_counter,
+					(int32_t)SIGN_EXTEND_TO_16(
+						freq_comp, 15),
+					ref_pwr_lvl,
+					num_ant_paths,
+					(abort_reason >> 4) & 0x0F,
+					0,
+					steps,
+					num_steps_reported);
+
+		if (steps) {
+			size_t k;
+
+			for (k = 0; k < num_steps_reported; k++) {
+				uint8_t mode = steps[k].step_mode & 0x03;
+				cs_mode_two_data *m2 = NULL;
+
+				if (mode == CS_MODE_TWO)
+					m2 = &steps[k].step_mode_data
+						    .mode_two_data;
+				else if (mode == CS_MODE_THREE)
+					m2 = &steps[k].step_mode_data
+						    .mode_three_data
+						    .mode_two_data;
+				if (m2) {
+					free(m2->tone_pct_iq_samples);
+					free(m2->tone_quality_indicators);
+				}
+			}
+			free(steps);
+		}
+
+		if (!subevent)
+			return;
+
+		bcs_procedure_data_add_initiator_subevent(bcs, subevent);
+	} else {
+		cs_subevent_result_data *last;
+		cs_step_data *new_steps;
+		int64_t old_count, new_count;
+
+		if (!bcs->initiator_subevent_result_data ||
+				bcs->initiator_subevent_result_data_size == 0)
+			return;
+
+		last = &bcs->initiator_subevent_result_data[
+				bcs->initiator_subevent_result_data_size - 1];
+
+		old_count = last->step_data_size;
+		new_count = old_count + num_steps_reported;
+
+		if (num_steps_reported > 0) {
+			new_steps = realloc(last->step_data,
+					new_count * sizeof(cs_step_data));
+			if (!new_steps)
+				return;
+
+			last->step_data = new_steps;
+
+			for (i = 0; i < num_steps_reported; i++)
+				hci_step_to_bcs_step(
+					&hci_steps[i],
+					&new_steps[old_count + i],
+					reqtracker->rtt_type,
+					num_ant_paths);
+
+			last->step_data_size = new_count;
+		}
+
+		last->subevent_abort_reason = (abort_reason >> 4) & 0x0F;
+	}
+
+	check_cs_procedure_complete(rap, reqtracker);
+}
+
+static void fill_initiator_data_from_cs_subevent_result_cont(struct bt_rap *rap,
+		const struct rap_ev_cs_subevent_result_cont *cont,
+		uint16_t length)
+{
+	size_t base_len = offsetof(struct rap_ev_cs_subevent_result_cont,
+					step_data);
+	struct cstracker *reqtracker;
+
+	if (!rap || !rap->reqtracker || !cont)
+		return;
+
+	if (length < base_len)
+		return;
+
+	DBG(rap, "Received CS subevent result continue subevent: len=%d",
+		length);
+
+	reqtracker = rap->reqtracker;
+
+	parse_cs_local_initiator_data(rap,
+				false,
+				cont->config_id,
+				cont->num_ant_paths,
+				reqtracker->last_proc_counter,
+				reqtracker->last_start_acl_conn_evt_counter,
+				reqtracker->last_freq_comp,
+				reqtracker->last_ref_pwr_lvl,
+				cont->proc_done_status,
+				cont->subevt_done_status,
+				cont->abort_reason,
+				cont->num_steps_reported,
+				cont->step_data);
+}
+
+static void fill_initiator_data_from_cs_subevent_result(struct bt_rap *rap,
+		const struct rap_ev_cs_subevent_result *data,
+		uint16_t length)
+{
+	size_t base_len = offsetof(struct rap_ev_cs_subevent_result,
+					step_data);
+
+	if (!rap || !rap->reqtracker || !data)
+		return;
+
+	if (length < base_len)
+		return;
+
+	DBG(rap, "Received CS subevent result subevent: len=%d", length);
+
+	parse_cs_local_initiator_data(rap,
+				true,
+				data->config_id,
+				data->num_ant_paths,
+				data->proc_counter,
+				data->start_acl_conn_evt_counter,
+				data->freq_comp,
+				data->ref_pwr_lvl,
+				data->proc_done_status,
+				data->subevt_done_status,
+				data->abort_reason,
+				data->num_steps_reported,
+				data->step_data);
+}
+
 void bt_rap_hci_cs_subevent_result_cont_callback(uint16_t length,
 						const void *param,
 						void *user_data)
@@ -1707,7 +2152,12 @@ void bt_rap_hci_cs_subevent_result_cont_callback(uint16_t length,
 
 	DBG(rap, "Received CS subevent CONT: len=%d", length);
 
-	form_ras_data_with_cs_subevent_result_cont(rap, cont, length);
+	if (rap->resptracker && rap->resptracker->role == CS_REFLECTOR)
+		form_ras_data_with_cs_subevent_result_cont(rap, cont, length);
+
+	if (rap->reqtracker && rap->reqtracker->role == CS_INITIATOR)
+		fill_initiator_data_from_cs_subevent_result_cont(rap,
+							cont, length);
 }
 
 void bt_rap_hci_cs_subevent_result_callback(uint16_t length,
@@ -1719,8 +2169,12 @@ void bt_rap_hci_cs_subevent_result_callback(uint16_t length,
 
 	DBG(rap, "Received CS subevent: len=%d", length);
 
-	/* Populate CsProcedureData and send RAS payload */
-	form_ras_data_with_cs_subevent_result(rap, data, length);
+	if (rap->resptracker && rap->resptracker->role == CS_REFLECTOR)
+		/* Populate CsProcedureData and send RAS payload */
+		form_ras_data_with_cs_subevent_result(rap, data, length);
+
+	if (rap->reqtracker && rap->reqtracker->role == CS_INITIATOR)
+		fill_initiator_data_from_cs_subevent_result(rap, data, length);
 }
 
 void bt_rap_hci_cs_procedure_enable_complete_callback(uint16_t length,
@@ -1730,6 +2184,7 @@ void bt_rap_hci_cs_procedure_enable_complete_callback(uint16_t length,
 	const struct rap_ev_cs_proc_enable_cmplt *data = param;
 	struct bt_rap *rap = user_data;
 	struct cstracker *resptracker;
+	struct cstracker *reqtracker;
 
 	DBG(rap, "Received CS procedure enable complete subevent: len=%d",
 	    length);
@@ -1745,6 +2200,23 @@ void bt_rap_hci_cs_procedure_enable_complete_callback(uint16_t length,
 	/* Populate responder tracker */
 	resptracker->config_id = data->config_id;
 	resptracker->selected_tx_power = data->sel_tx_pwr;
+
+	if (!rap->reqtracker) {
+		reqtracker = new0(struct cstracker, 1);
+		cs_tracker_init(reqtracker);
+		rap->reqtracker = reqtracker;
+	}
+
+	reqtracker = rap->reqtracker;
+	/* Initiator-side local cache for algo path */
+	reqtracker->config_id = data->config_id;
+	reqtracker->selected_tx_power = data->sel_tx_pwr;
+	reqtracker->bcs_proc_data.initiator_selected_tx_power =
+					data->sel_tx_pwr;
+
+	reqtracker->proc_start_timestamp_nanos = get_time_nanos();
+	DBG(rap, "Procedure enabled - start timestamp: %ld nanos",
+	    reqtracker->proc_start_timestamp_nanos);
 }
 
 void bt_rap_hci_cs_sec_enable_complete_callback(uint16_t length,
@@ -1763,6 +2235,7 @@ void bt_rap_hci_cs_config_complete_callback(uint16_t length,
 	const struct rap_ev_cs_config_cmplt *data = param;
 	struct bt_rap *rap = user_data;
 	struct cstracker *resptracker;
+	struct cstracker *reqtracker;
 
 	if (!rap)
 		return;
@@ -1781,6 +2254,20 @@ void bt_rap_hci_cs_config_complete_callback(uint16_t length,
 	resptracker->config_id = data->config_id;
 	resptracker->role = data->role;
 	resptracker->rtt_type = data->rtt_type;
+
+	if (!rap->reqtracker) {
+		reqtracker = new0(struct cstracker, 1);
+		cs_tracker_init(reqtracker);
+		rap->reqtracker = reqtracker;
+	}
+
+	reqtracker = rap->reqtracker;
+
+	/* Basic fields */
+	reqtracker->config_id = data->config_id;
+	reqtracker->role = data->role;
+	reqtracker->rtt_type = data->rtt_type;
+	reqtracker->procedure_sequence_after_enable = -1;
 }
 
 struct bt_rap *bt_rap_new(struct gatt_db *ldb, struct gatt_db *rdb)
@@ -1813,6 +2300,1036 @@ done:
 	bt_rap_ref(rap);
 
 	return rap;
+}
+
+static void ras_pending_destroy(void *data)
+{
+	struct bt_rap_pending *pending = data;
+	struct bt_rap *rap = pending->rap;
+
+	if (queue_remove_if(rap->pending, NULL, pending))
+		free(pending);
+}
+
+static void ras_pending_complete(bool success, uint8_t att_ecode,
+				const uint8_t *value, uint16_t length,
+				void *user_data)
+{
+	struct bt_rap_pending *pending = user_data;
+
+	if (pending->func)
+		pending->func(pending->rap, success, att_ecode, value, length,
+					  pending->userdata);
+}
+
+static void rap_read_value(struct bt_rap *rap, uint16_t value_handle,
+			   rap_func_t func, void *user_data)
+{
+	struct bt_rap_pending *pending;
+
+	pending = new0(struct bt_rap_pending, 1);
+	pending->rap = rap;
+	pending->func = func;
+	pending->userdata = user_data;
+
+	pending->id = bt_gatt_client_read_value(rap->client, value_handle,
+						ras_pending_complete, pending,
+						ras_pending_destroy);
+	if (!pending->id) {
+		DBG(rap, "Unable to send Read request");
+		free(pending);
+		return;
+	}
+
+	queue_push_tail(rap->pending, pending);
+}
+
+static void ras_register(uint16_t att_ecode, void *user_data)
+{
+	struct bt_rap_notify *notify = user_data;
+
+	if (att_ecode)
+		DBG(notify->rap, "RAS register failed 0x%04x", att_ecode);
+
+	(void)notify;
+}
+
+static void rap_notify(uint16_t value_handle, const uint8_t *value,
+				uint16_t length, void *user_data)
+{
+	struct bt_rap_notify *notify = user_data;
+
+	if (notify->func)
+		notify->func(notify->rap, value_handle, value, length,
+					 notify->user_data);
+}
+
+static void rap_notify_destroy(void *data)
+{
+	struct bt_rap_notify *notify = data;
+	struct bt_rap *rap = notify->rap;
+
+	if (queue_remove_if(rap->notify, NULL, notify))
+		free(notify);
+}
+
+static unsigned int bt_rap_register_notify(struct bt_rap *rap,
+					uint16_t value_handle,
+					rap_notify_t func,
+					void *user_data)
+{
+	struct bt_rap_notify *notify;
+
+	notify = new0(struct bt_rap_notify, 1);
+	notify->rap = rap;
+	notify->func = func;
+	notify->user_data = user_data;
+
+	DBG(rap, "register for notifications");
+
+	notify->id = bt_gatt_client_register_notify(rap->client,
+					value_handle, ras_register,
+					rap_notify, notify,
+					rap_notify_destroy);
+	if (!notify->id) {
+		DBG(rap, "Unable to register for notifications");
+		free(notify);
+		return 0;
+	}
+
+	queue_push_tail(rap->notify, notify);
+
+	return notify->id;
+}
+
+static inline size_t parse_segmentation_header(const uint8_t *in,
+					size_t in_len,
+					struct segmentation_header *s)
+{
+	uint8_t byte;
+
+	if (!in || !s || in_len < 1)
+		return 0;
+
+	byte = in[0];
+
+	/* Extract bit fields:
+	 * bit 0: first_segment
+	 * bit 1: last_segment
+	 * bits 2-7: rolling_segment_counter (6 bits)
+	 */
+	s->first_segment = (byte & 0x01) ? 1 : 0;
+	s->last_segment = (byte & 0x02) ? 1 : 0;
+	s->rolling_segment_counter = (byte >> 2) & 0x3F;
+
+	return 1;
+}
+
+static void parse_i_q_sample(struct iovec *iov, int16_t *i_sample,
+				int16_t *q_sample)
+{
+	uint32_t buffer;
+	uint32_t i12;
+	uint32_t q12;
+
+	/* Pull 24-bit little-endian value from iovec */
+	if (!util_iov_pull_le24(iov, &buffer)) {
+		*i_sample = 0;
+		*q_sample = 0;
+		return;
+	}
+
+	/* Extract 12-bit I and Q values from 24-bit buffer */
+	i12 =  buffer        & 0x0FFFU;   /* bits 0..11 */
+	q12 = (buffer >> 12) & 0x0FFFU;   /* bits 12..23 */
+
+	/* Sign-extend 12-bit values to 16-bit using macro */
+	*i_sample = SIGN_EXTEND_TO_16(i12, 12);
+	*q_sample = SIGN_EXTEND_TO_16(q12, 12);
+}
+
+static size_t get_mode_zero_length(enum cs_role remote_role)
+{
+	return (remote_role == CS_ROLE_INITIATOR) ?
+			CS_MODE_ZERO_WIRE_INIT_SIZE :
+			CS_MODE_ZERO_WIRE_REF_SIZE;
+}
+
+static bool parse_mode_zero(struct bt_rap *rap, struct iovec *mode_iov,
+			    enum cs_role remote_role, cs_step_data *step)
+{
+	cs_mode_zero_data *m0 = &step->step_mode_data.mode_zero_data;
+
+	if (!util_iov_pull_u8(mode_iov, (uint8_t *)&m0->packet_quality) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m0->packet_rssi_dbm) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m0->packet_antenna)) {
+		DBG(rap, "Mode 0: failed to parse common fields");
+		return false;
+	}
+
+	m0->initiator_measured_freq_offset = 0;
+	if (remote_role == CS_ROLE_INITIATOR) {
+		if (!util_iov_pull_le32(mode_iov, (uint32_t *)
+				&m0->initiator_measured_freq_offset)) {
+			DBG(rap, "Mode 0: failed to parse freq offset");
+			return false;
+		}
+	}
+
+	if (remote_role == CS_ROLE_INITIATOR) {
+		DBG(rap, "    cs_mode_zero_data (INITIATOR): "
+			"Packet_Quality=%u Packet_RSSI=%d "
+			"Packet_Antenna=%u Measured_Freq_Offset=%u",
+			(uint8_t)m0->packet_quality, m0->packet_rssi_dbm,
+			(uint8_t)m0->packet_antenna,
+			(uint32_t)m0->initiator_measured_freq_offset);
+	} else {
+		DBG(rap, "    cs_mode_zero_data (REFLECTOR): "
+			"Packet_Quality=%u Packet_RSSI=%d "
+			"Packet_Antenna=%u",
+			(uint8_t)m0->packet_quality, m0->packet_rssi_dbm,
+			(uint8_t)m0->packet_antenna);
+	}
+
+	step->step_mode = CS_MODE_ZERO;
+	return true;
+}
+
+/* Helper function to get expected payload length for CS Mode 1 */
+static size_t get_mode_one_length(bool include_pct)
+{
+	/* Mode 1: variable length based on PCT inclusion
+	 * 6 bytes without PCT, 12 bytes with PCT
+	 */
+	if (include_pct)
+		return CS_MODE_ONE_WIRE_SIZE_MAX;
+	return CS_MODE_ONE_WIRE_SIZE_MIN;
+}
+
+/* Helper function to parse CS Mode 1 data */
+static bool parse_mode_one(struct bt_rap *rap, struct iovec *mode_iov,
+			   enum cs_role remote_role, bool include_pct,
+			   cs_step_data *step)
+{
+	cs_mode_one_data *m1 = &step->step_mode_data.mode_one_data;
+	int16_t time_value;
+	int16_t pct1_i = 0, pct1_q = 0;
+	int16_t pct2_i = 0, pct2_q = 0;
+
+	if (!util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_quality) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_nadm) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_rssi_dbm) ||
+	    !util_iov_pull_le16(mode_iov, (uint16_t *)&time_value) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_antenna)) {
+		DBG(rap, "Mode 1: failed to parse fixed fields");
+		return false;
+	}
+
+	if (include_pct) {
+		parse_i_q_sample(mode_iov, &pct1_i, &pct1_q);
+		parse_i_q_sample(mode_iov, &pct2_i, &pct2_q);
+	}
+
+	if (remote_role == CS_ROLE_REFLECTOR)
+		m1->rtt_toa_tod_data.tod_toa_reflector = (int32_t)time_value;
+	else
+		m1->rtt_toa_tod_data.toa_tod_initiator = (int32_t)time_value;
+
+	m1->packet_pct1.i_sample = (int32_t)pct1_i;
+	m1->packet_pct1.q_sample = (int32_t)pct1_q;
+	m1->packet_pct2.i_sample = (int32_t)pct2_i;
+	m1->packet_pct2.q_sample = (int32_t)pct2_q;
+
+	if (remote_role == CS_ROLE_INITIATOR) {
+		DBG(rap, "    cs_mode_one_data (INITIATOR): "
+			"Packet_Quality=%u Packet_NADM=%u "
+			"Packet_RSSI=%d ToA_ToD_Initiator=0x%4.4x "
+			"Packet_Antenna=%u",
+			(uint8_t)m1->packet_quality, (uint8_t)m1->packet_nadm,
+			m1->packet_rssi_dbm, time_value,
+			(uint8_t)m1->packet_antenna);
+		if (include_pct)
+			DBG(rap, "    cs_mode_one_data (INITIATOR): "
+				"Packet_PCT1(I=0x%3.3x,Q=0x%3.3x) "
+				"Packet_PCT2(I=0x%3.3x,Q=0x%3.3x)",
+				pct1_i, pct1_q, pct2_i, pct2_q);
+	} else {
+		DBG(rap, "    cs_mode_one_data (REFLECTOR): "
+			"Packet_Quality=%u Packet_NADM=%u "
+			"Packet_RSSI=%d ToD_ToA_Reflector=0x%4.4x  "
+			"Packet_Antenna=%u",
+			(uint8_t)m1->packet_quality, (uint8_t)m1->packet_nadm,
+			m1->packet_rssi_dbm, time_value,
+			(uint8_t)m1->packet_antenna);
+		if (include_pct)
+			DBG(rap, "    cs_mode_one_data (REFLECTOR): "
+				"Packet_PCT1(I=0x%3.3x,Q=0x%3.3x) "
+				"Packet_PCT2(I=0x%3.3x,Q=0x%3.3x)",
+				pct1_i, pct1_q, pct2_i, pct2_q);
+	}
+
+	step->step_mode = CS_MODE_ONE;
+	return true;
+}
+
+/* Helper function to get expected payload length for CS Mode 2 */
+static size_t get_mode_two_length(uint8_t num_antenna_paths)
+{
+	uint8_t num_tone_data = num_antenna_paths + 1;
+
+	return 1 + (4 * num_tone_data);
+}
+
+/* Helper function to parse CS Mode 2 data */
+static bool parse_mode_two(struct bt_rap *rap, struct iovec *mode_iov,
+			   uint8_t num_antenna_paths, cs_step_data *step)
+{
+	cs_mode_two_data *m2 = &step->step_mode_data.mode_two_data;
+	int16_t tone_pct_i[5];
+	int16_t tone_pct_q[5];
+	uint8_t k;
+	uint8_t num_paths = (num_antenna_paths + 1) < 5 ?
+		(num_antenna_paths + 1) : 5;
+
+	if (!util_iov_pull_u8(mode_iov,
+			(uint8_t *)&m2->antenna_permutation_index)) {
+		DBG(rap, "Mode 2: failed to parse ant_perm_index");
+		return false;
+	}
+
+	m2->tone_pct_iq_samples = calloc(num_paths, sizeof(cs_pct_iq_sample));
+	m2->tone_quality_indicators = calloc(num_paths, 1);
+	if (!m2->tone_pct_iq_samples || !m2->tone_quality_indicators) {
+		free(m2->tone_pct_iq_samples);
+		free(m2->tone_quality_indicators);
+		m2->tone_pct_iq_samples = NULL;
+		m2->tone_quality_indicators = NULL;
+		return false;
+	}
+
+	for (k = 0; k < num_paths; k++) {
+		parse_i_q_sample(mode_iov, &tone_pct_i[k], &tone_pct_q[k]);
+		util_iov_pull_u8(mode_iov, &m2->tone_quality_indicators[k]);
+		m2->tone_pct_iq_samples[k].i_sample = (int32_t)tone_pct_i[k];
+		m2->tone_pct_iq_samples[k].q_sample = (int32_t)tone_pct_q[k];
+		DBG(rap, "tone_quality_indicator : %d",
+			m2->tone_quality_indicators[k]);
+		DBG(rap, "[i, q] : %d, %d", tone_pct_i[k], tone_pct_q[k]);
+	}
+
+	m2->tone_pct_iq_sample_size      = num_paths;
+	m2->tone_quality_indicators_size = num_paths;
+
+	DBG(rap, "    cs_mode_two_data: ant_perm_idx=%u",
+		(uint8_t)m2->antenna_permutation_index);
+	for (k = 0; k < num_paths; k++) {
+		DBG(rap, "      tone[%u]: pct(I=0x%3.3x,Q=0x%3.3x) quality=%u",
+			k, tone_pct_i[k], tone_pct_q[k],
+			m2->tone_quality_indicators[k]);
+	}
+
+	step->step_mode = CS_MODE_TWO;
+	return true;
+}
+
+/* Helper function to get expected payload length for CS Mode 3 */
+static size_t get_mode_three_length(uint8_t num_antenna_paths, bool include_pct)
+{
+	uint8_t num_tone_data = num_antenna_paths + 1;
+	size_t len;
+
+	/* Mode 1 portion: 6 bytes base + optional 6 bytes PCT */
+	len = 6;
+	if (include_pct)
+		len += 6;
+
+	/* Mode 2 portion: 1 byte antenna index + 4 bytes per tone */
+	len += 1 + (4 * num_tone_data);
+
+	return len;
+}
+
+/* Helper function to parse CS Mode 3 data */
+static bool parse_mode_three(struct bt_rap *rap, struct iovec *mode_iov,
+			     enum cs_role remote_role, bool include_pct,
+			     uint8_t num_antenna_paths, cs_step_data *step)
+{
+	cs_mode_one_data *m1 =
+		&step->step_mode_data.mode_three_data.mode_one_data;
+	cs_mode_two_data *m2 =
+		&step->step_mode_data.mode_three_data.mode_two_data;
+	int16_t time_value;
+	int16_t pct1_i = 0, pct1_q = 0;
+	int16_t pct2_i = 0, pct2_q = 0;
+	int16_t tone_pct_i[5];
+	int16_t tone_pct_q[5];
+	uint8_t k;
+	uint8_t num_paths = (num_antenna_paths + 1) < 5 ?
+		(num_antenna_paths + 1) : 5;
+
+	if (!util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_quality) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_nadm) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_rssi_dbm) ||
+	    !util_iov_pull_le16(mode_iov, (uint16_t *)&time_value) ||
+	    !util_iov_pull_u8(mode_iov, (uint8_t *)&m1->packet_antenna)) {
+		DBG(rap, "Mode 3: failed to parse Mode 1 fixed fields");
+		return false;
+	}
+
+	if (include_pct) {
+		parse_i_q_sample(mode_iov, &pct1_i, &pct1_q);
+		parse_i_q_sample(mode_iov, &pct2_i, &pct2_q);
+	}
+
+	if (!util_iov_pull_u8(mode_iov,
+			(uint8_t *)&m2->antenna_permutation_index)) {
+		DBG(rap, "Mode 3: failed to parse ant_perm_index");
+		return false;
+	}
+
+	m2->tone_pct_iq_samples = calloc(num_paths, sizeof(cs_pct_iq_sample));
+	m2->tone_quality_indicators = calloc(num_paths, 1);
+	if (!m2->tone_pct_iq_samples || !m2->tone_quality_indicators) {
+		free(m2->tone_pct_iq_samples);
+		free(m2->tone_quality_indicators);
+		m2->tone_pct_iq_samples = NULL;
+		m2->tone_quality_indicators = NULL;
+		return false;
+	}
+
+	for (k = 0; k < num_paths; k++) {
+		parse_i_q_sample(mode_iov, &tone_pct_i[k], &tone_pct_q[k]);
+		util_iov_pull_u8(mode_iov, &m2->tone_quality_indicators[k]);
+		m2->tone_pct_iq_samples[k].i_sample = (int32_t)tone_pct_i[k];
+		m2->tone_pct_iq_samples[k].q_sample = (int32_t)tone_pct_q[k];
+		DBG(rap, "tone_quality_indicator : %d",
+			m2->tone_quality_indicators[k]);
+		DBG(rap, "[i, q] : %d, %d", tone_pct_i[k], tone_pct_q[k]);
+	}
+
+	if (remote_role == CS_ROLE_REFLECTOR)
+		m1->rtt_toa_tod_data.tod_toa_reflector = (int32_t)time_value;
+	else
+		m1->rtt_toa_tod_data.toa_tod_initiator = (int32_t)time_value;
+
+	m1->packet_pct1.i_sample = (int32_t)pct1_i;
+	m1->packet_pct1.q_sample = (int32_t)pct1_q;
+	m1->packet_pct2.i_sample = (int32_t)pct2_i;
+	m1->packet_pct2.q_sample = (int32_t)pct2_q;
+
+	m2->tone_pct_iq_sample_size      = num_paths;
+	m2->tone_quality_indicators_size = num_paths;
+
+	if (remote_role == CS_ROLE_INITIATOR) {
+		DBG(rap, "    cs_mode_three_data (INITIATOR): "
+			"Packet_Quality=%u Packet_NADM=%u "
+			"Packet_RSSI=%d ToA_ToD_Initiator=0x%4.4x "
+			"Packet_Antenna=%u",
+			(uint8_t)m1->packet_quality, (uint8_t)m1->packet_nadm,
+			m1->packet_rssi_dbm, time_value,
+			(uint8_t)m1->packet_antenna);
+		if (include_pct)
+			DBG(rap, "    cs_mode_three_data (INITIATOR): "
+				"Packet_PCT1(I=0x%3.3x,Q=0x%3.3x) "
+				"Packet_PCT2(I=0x%3.3x,Q=0x%3.3x)",
+				pct1_i, pct1_q, pct2_i, pct2_q);
+		DBG(rap, "    cs_mode_three_data (INITIATOR): "
+			"Antenna_Permutation_Index=%u",
+			(uint8_t)m2->antenna_permutation_index);
+		for (k = 0; k < num_paths; k++)
+			DBG(rap, "      Tone_PCT[%u](I=0x%3.3x,Q=0x%3.3x) "
+				"Tone_Quality_Indicator[%u]=%u",
+				k, tone_pct_i[k], tone_pct_q[k], k,
+				m2->tone_quality_indicators[k]);
+	} else {
+		DBG(rap, "    cs_mode_three_data (REFLECTOR): "
+			"Packet_Quality=%u Packet_NADM=%u "
+			"Packet_RSSI=%d ToD_ToA_Reflector=0x%4.4x "
+			"Packet_Antenna=%u",
+			(uint8_t)m1->packet_quality, (uint8_t)m1->packet_nadm,
+			m1->packet_rssi_dbm, time_value,
+			(uint8_t)m1->packet_antenna);
+		if (include_pct)
+			DBG(rap, "    cs_mode_three_data (REFLECTOR): "
+				"Packet_PCT1(I=0x%3.3x,Q=0x%3.3x) "
+				"Packet_PCT2(I=0x%3.3x,Q=0x%3.3x)",
+				pct1_i, pct1_q, pct2_i, pct2_q);
+		DBG(rap, "    cs_mode_three_data (REFLECTOR): "
+			"Antenna_Permutation_Index=%u",
+			(uint8_t)m2->antenna_permutation_index);
+		for (k = 0; k < num_paths; k++)
+			DBG(rap, "      Tone_PCT[%u](I=0x%3.3x,Q=0x%3.3x) "
+				"Tone_Quality_Indicator[%u]=%u",
+				k, tone_pct_i[k], tone_pct_q[k], k,
+				m2->tone_quality_indicators[k]);
+	}
+
+	step->step_mode = CS_MODE_THREE;
+	return true;
+}
+
+static void parse_ras_segments(struct bt_rap *rap,
+			       struct cstracker *reqtracker)
+{
+	const uint8_t *buf;
+	size_t buf_len;
+	size_t offset = 0;
+	uint8_t antenna_mask;
+	uint8_t num_antenna_paths;
+	enum cs_role local_role;
+	enum cs_role remote_role;
+	bcs_procedure_data *bcs;
+	uint8_t rtt_type;
+	bool include_pct;
+	uint8_t subevent_idx = 0;
+
+	if (!rap || !reqtracker)
+		return;
+
+	DBG(rap, "Complete RAS data received: %zu bytes",
+	    reqtracker->segment_data.iov_len);
+
+	antenna_mask = ranging_header_get_antenna_mask(
+					&reqtracker->ranging_header_);
+	num_antenna_paths = antenna_mask_count_paths(antenna_mask);
+
+	local_role  = reqtracker->role;
+	remote_role = (local_role == CS_ROLE_INITIATOR) ?
+			CS_ROLE_REFLECTOR : CS_ROLE_INITIATOR;
+	rtt_type    = reqtracker->rtt_type;
+	include_pct = (rtt_type != 0x00);
+	bcs         = &reqtracker->bcs_proc_data;
+
+	/* Issue 4: record reflector TX power from RAS ranging header */
+	bcs->reflector_selected_tx_power =
+		reqtracker->ranging_header_.selected_tx_power;
+
+	buf     = (const uint8_t *)reqtracker->segment_data.iov_base;
+	buf_len = reqtracker->segment_data.iov_len;
+
+	while (offset + RAS_SUBEVENT_HEADER_SIZE <= buf_len) {
+		struct ras_subevent_header subevt_hdr;
+		const uint8_t *hdr = buf + offset;
+		uint8_t done_byte;
+		uint8_t abort_byte;
+		cs_step_data *steps = NULL;
+		uint8_t num_valid_steps = 0;
+		uint8_t local_step_idx = 0;
+		cs_subevent_result_data *subevent;
+		int64_t timestamp_nanos = 0;
+		uint8_t step_idx;
+
+		subevt_hdr.start_acl_conn_event    = get_le16(hdr);
+		subevt_hdr.frequency_compensation  = get_le16(hdr + 2);
+
+		done_byte = hdr[4];
+		subevt_hdr.ranging_done_status  =
+			RAS_DONE_STATUS_UNPACK_RANGING(done_byte);
+		subevt_hdr.subevent_done_status =
+			RAS_DONE_STATUS_UNPACK_SUBEVENT(done_byte);
+
+		abort_byte = hdr[5];
+		subevt_hdr.ranging_abort_reason  =
+			RAS_ABORT_REASON_UNPACK_RANGING(abort_byte);
+		subevt_hdr.subevent_abort_reason =
+			RAS_ABORT_REASON_UNPACK_SUBEVENT(abort_byte);
+
+		subevt_hdr.reference_power_level = (int8_t)hdr[6];
+		subevt_hdr.num_steps_reported    = hdr[7];
+
+		DBG(rap, "Parsed subevent: start_acl=%u "
+			"freq_comp=%d ref_pwr=%d steps=%u",
+		    subevt_hdr.start_acl_conn_event,
+		    subevt_hdr.frequency_compensation,
+		    subevt_hdr.reference_power_level,
+		    subevt_hdr.num_steps_reported);
+
+		offset += RAS_SUBEVENT_HEADER_SIZE;
+
+		/* Update reqtracker with remote completion status */
+		reqtracker->remote_proc_done_status =
+			(enum cs_procedure_done_status)
+					subevt_hdr.ranging_done_status;
+		if (subevt_hdr.subevent_done_status ==
+					SUBEVENT_DONE_ALL_RESULTS_COMPLETE)
+			reqtracker->remote_has_complete_subevent = true;
+
+		/* Issue 5: record reflector procedure abort reason */
+		if (subevt_hdr.ranging_abort_reason)
+			bcs->reflector_procedure_abort_reason =
+				(int8_t)subevt_hdr.ranging_abort_reason;
+
+		/* Borrow timestamp from matching local initiator subevent */
+		if (subevent_idx <
+			(uint8_t)bcs->initiator_subevent_result_data_size)
+			timestamp_nanos =
+				bcs->initiator_subevent_result_data
+					[subevent_idx].timestamp_nanos;
+
+		if (subevt_hdr.num_steps_reported > 0) {
+			steps = calloc(subevt_hdr.num_steps_reported,
+				       sizeof(cs_step_data));
+			if (!steps) {
+				DBG(rap, "OOM allocating steps for subevent %u",
+				    subevent_idx);
+				break;
+			}
+		}
+
+		for (step_idx = 0;
+		     step_idx < subevt_hdr.num_steps_reported;
+		     step_idx++) {
+			uint8_t mode_byte;
+			bool step_aborted;
+			uint8_t step_mode;
+			size_t step_payload_len = 0;
+			uint8_t step_channel = 0;
+			cs_step_data *cur_step;
+			bool ok;
+
+			if (offset >= buf_len) {
+				DBG(rap, "Insufficient data for step %u",
+				    step_idx);
+				break;
+			}
+
+			mode_byte    = buf[offset++];
+			step_aborted = (mode_byte & RAS_STEP_ABORTED_BIT) != 0;
+			step_mode    = mode_byte & 0x7F;
+
+			if (step_aborted) {
+				DBG(rap, "  Step %u: mode=%u (aborted)",
+				    step_idx, step_mode);
+				continue;
+			}
+
+			switch (step_mode) {
+			case CS_MODE_ZERO:
+				step_payload_len =
+					get_mode_zero_length(remote_role);
+				break;
+			case CS_MODE_ONE:
+				step_payload_len =
+					get_mode_one_length(include_pct);
+				break;
+			case CS_MODE_TWO:
+				step_payload_len =
+					get_mode_two_length(num_antenna_paths);
+				break;
+			case CS_MODE_THREE:
+				step_payload_len = get_mode_three_length(
+							num_antenna_paths,
+							include_pct);
+				break;
+			default:
+				DBG(rap, "  Step %u: unknown mode=%u",
+				    step_idx, step_mode);
+				break;
+			}
+
+			if (step_payload_len == 0) {
+				DBG(rap, "  Step %u: no payload, skipping",
+				    step_idx);
+				continue;
+			}
+
+			if (offset + step_payload_len > buf_len) {
+				DBG(rap, "Insufficient data for step %u "
+					"payload (need %zu, have %zu)",
+				    step_idx, step_payload_len,
+				    buf_len - offset);
+				break;
+			}
+
+			DBG(rap, "  Step %u: mode=%u payload_len=%zu",
+			    step_idx, step_mode, step_payload_len);
+
+			/*
+			 * Look up step_channel from the matching local
+			 * initiator subevent.  Both sides use the same
+			 * channel sequence, so indices stay in sync as long
+			 * as abort patterns match.
+			 */
+			if (subevent_idx <
+			    (uint8_t)bcs->initiator_subevent_result_data_size &&
+			    local_step_idx <
+			    (uint8_t)bcs->initiator_subevent_result_data
+					[subevent_idx].step_data_size)
+				step_channel = (uint8_t)
+					bcs->initiator_subevent_result_data
+					[subevent_idx].step_data
+					[local_step_idx].step_channel;
+			local_step_idx++;
+
+			cur_step = &steps[num_valid_steps];
+			cur_step->step_channel = (int8_t)step_channel;
+
+			{
+				const uint8_t *payload_ptr = buf + offset;
+				struct iovec mode_iov;
+
+				mode_iov.iov_base = (void *)payload_ptr;
+				mode_iov.iov_len  = step_payload_len;
+
+				switch (step_mode) {
+				case CS_MODE_ZERO:
+					ok = parse_mode_zero(rap, &mode_iov,
+							     remote_role,
+							     cur_step);
+					break;
+				case CS_MODE_ONE:
+					ok = parse_mode_one(rap, &mode_iov,
+							    remote_role,
+							    include_pct,
+							    cur_step);
+					break;
+				case CS_MODE_TWO:
+					ok = parse_mode_two(rap, &mode_iov,
+							    num_antenna_paths,
+							    cur_step);
+					break;
+				case CS_MODE_THREE:
+					ok = parse_mode_three(rap, &mode_iov,
+							      remote_role,
+							      include_pct,
+							      num_antenna_paths,
+							      cur_step);
+					break;
+				default:
+					ok = false;
+					break;
+				}
+			}
+
+			offset += step_payload_len;
+
+			if (!ok) {
+				DBG(rap, "  Step %u: parse failed, skipping",
+				    step_idx);
+				memset(cur_step, 0, sizeof(*cur_step));
+				continue;
+			}
+
+			num_valid_steps++;
+		}
+
+		/* Build BCS subevent and commit to bcs_proc_data */
+		subevent = bcs_subevent_result_data_new(
+				(int32_t)subevt_hdr.start_acl_conn_event,
+				(int32_t)SIGN_EXTEND_TO_16(
+					subevt_hdr.frequency_compensation, 15),
+				subevt_hdr.reference_power_level,
+				(int8_t)num_antenna_paths,
+				(int8_t)subevt_hdr.subevent_abort_reason,
+				timestamp_nanos,
+				steps,
+				(int64_t)num_valid_steps);
+
+		/*
+		 * Free heap allocations in the temp steps array.
+		 * bcs_subevent_result_data_new deep-copies the steps,
+		 * so we own and must release the originals.
+		 */
+		if (steps) {
+			uint8_t k;
+
+			for (k = 0; k < num_valid_steps; k++) {
+				uint8_t mode = steps[k].step_mode & 0x03;
+				cs_mode_two_data *m2 = NULL;
+
+				if (mode == CS_MODE_TWO)
+					m2 = &steps[k].step_mode_data
+						    .mode_two_data;
+				else if (mode == CS_MODE_THREE)
+					m2 = &steps[k].step_mode_data
+						    .mode_three_data
+						    .mode_two_data;
+				if (m2) {
+					free(m2->tone_pct_iq_samples);
+					free(m2->tone_quality_indicators);
+				}
+			}
+			free(steps);
+		}
+
+		if (subevent) {
+			if (remote_role == CS_ROLE_REFLECTOR)
+				bcs_procedure_data_add_reflector_subevent(
+							bcs, subevent);
+			else
+				bcs_procedure_data_add_initiator_subevent(
+							bcs, subevent);
+		}
+
+		subevent_idx++;
+
+		if (subevt_hdr.subevent_done_status ==
+		    SUBEVENT_DONE_ALL_RESULTS_COMPLETE ||
+		    subevt_hdr.ranging_done_status ==
+		    RANGING_DONE_ALL_RESULTS_COMPLETE) {
+			DBG(rap, "Ranging procedure complete");
+			break;
+		}
+	}
+
+	/*
+	 * Remote RAS data is now stored in bcs->reflector_subevent_result_data.
+	 * Attempt delivery — check_cs_procedure_complete will send only if
+	 * local (HCI) data is also complete.  In the typical BlueZ timing,
+	 * local HCI data arrives first so this is the winning trigger.
+	 */
+	check_cs_procedure_complete(rap, reqtracker);
+
+	free(reqtracker->segment_data.iov_base);
+	reqtracker->segment_data.iov_base = NULL;
+	reqtracker->segment_data.iov_len  = 0;
+}
+
+static void ras_realtime_notify_cb(struct bt_rap *rap, uint16_t value_handle,
+				   const uint8_t *value, uint16_t length,
+				   void *user_data)
+{
+	struct segmentation_header seg_hdr;
+	const uint8_t *payload;
+	size_t payload_len;
+	size_t parsed;
+	struct cstracker *reqtracker;
+
+	if (!rap || !value || length == 0) {
+		DBG(rap, "Invalid notification data");
+		return;
+	}
+
+	DBG(rap, "Received real-time notification: handle=0x%04x len=%u",
+	    value_handle, length);
+
+	/* Parse segmentation header (first byte) */
+	if (length < 1) {
+		DBG(rap, "Notification too short for segmentation header");
+		return;
+	}
+
+	parsed = parse_segmentation_header(value, length, &seg_hdr);
+	if (parsed == 0) {
+		DBG(rap, "Failed to parse segmentation header");
+		return;
+	}
+
+	DBG(rap, "Segment: first=%u last=%u counter=%u",
+	    seg_hdr.first_segment, seg_hdr.last_segment,
+	    seg_hdr.rolling_segment_counter);
+
+	payload = value + parsed;
+	payload_len = length - parsed;
+
+	/* Ensure reqtracker exists */
+	if (!rap->reqtracker) {
+		struct cstracker *reqtracker_new = new0(struct cstracker, 1);
+
+		cs_tracker_init(reqtracker_new);
+		rap->reqtracker = reqtracker_new;
+	}
+
+	reqtracker = rap->reqtracker;
+
+	/* First segment: parse ranging header and initialize accumulator */
+	if (seg_hdr.first_segment) {
+		const uint8_t *rhdr;
+		uint16_t counter_config_val;
+
+		/* Parse ranging header (4 bytes) */
+		if (payload_len < RAS_RANGING_HEADER_SIZE) {
+			DBG(rap, "First segment too short for ranging header");
+			return;
+		}
+
+		/* Parse ranging header into reqtracker */
+		rhdr = payload;
+		counter_config_val = get_le16(rhdr);
+		reqtracker->ranging_header_.counter_config[0] =
+					counter_config_val & 0xFF;
+		reqtracker->ranging_header_.counter_config[1] =
+					(counter_config_val >> 8) & 0xFF;
+		reqtracker->ranging_header_.selected_tx_power =
+			(int8_t)rhdr[2];
+		reqtracker->ranging_header_.antenna_pct = rhdr[3];
+
+		DBG(rap, "First segment: parsed ranging header"
+		    " (counter=%u, config_id=%u, tx_pwr=%d)",
+		    counter_config_val & 0x0FFF,
+		    (counter_config_val >> 12) & 0x0F,
+		    (int8_t)rhdr[2]);
+
+		/* Clear accumulator before reinitializing */
+		if (reqtracker->segment_data.iov_base) {
+			free(reqtracker->segment_data.iov_base);
+			reqtracker->segment_data.iov_base = NULL;
+			reqtracker->segment_data.iov_len = 0;
+		}
+
+		/* Advance payload pointer past ranging header */
+		payload += RAS_RANGING_HEADER_SIZE;
+		payload_len -= RAS_RANGING_HEADER_SIZE;
+
+		/* Initialize accumulator with first segment payload */
+		if (payload_len > 0) {
+			if (!util_iov_append(&reqtracker->segment_data,
+					payload, payload_len)) {
+				DBG(rap, "Failed to init segment accumulator");
+				return;
+			}
+			DBG(rap, "First segment: init accumulator"
+			    " with %zu bytes", payload_len);
+		}
+
+		/* first=1 and last=1: process immediately */
+		if (seg_hdr.last_segment) {
+			DBG(rap, "Single-segment transmission"
+			    " (first=1, last=1) - processing immediately");
+		} else {
+			/* Wait for more segments */
+			return;
+		}
+	} else {
+
+		if (payload_len > 0) {
+			/* Append data using util_iov_append */
+			if (!util_iov_append(&reqtracker->segment_data,
+					payload, payload_len)) {
+				DBG(rap, "Failed to append segment data");
+				return;
+			}
+			DBG(rap, "Continuation segment: appended"
+			    " %zu bytes (total=%zu)",
+			    payload_len, reqtracker->segment_data.iov_len);
+		}
+	}
+
+	/* Last segment: parse complete RAS data */
+	if (seg_hdr.last_segment)
+		parse_ras_segments(rap, reqtracker);
+}
+/* RAS Features read callback - processes features value from remote server */
+static void read_ras_features(struct bt_rap *rap, bool success,
+			uint8_t att_ecode,
+			const uint8_t *value, uint16_t length,
+			void *user_data)
+{
+	struct iovec iov = { .iov_base = (void *)value, .iov_len = length };
+	uint32_t features = 0;
+	struct ras *ras;
+	bool supports_realtime;
+	bool supports_ondemand;
+	bool supports_abort;
+
+	if (!success) {
+		/*
+		 * ATT error 0x05 = Insufficient Authentication
+		 * ATT error 0x0F = Insufficient Encryption
+		 *
+		 * The server requires an encrypted/authenticated link.
+		 * Security must be established at the pairing/bonding level
+		 * before the GATT connection.
+		 */
+		ras = rap_get_ras(rap);
+		if (ras)
+			ras->features_read_pending = false;
+
+		if (att_ecode == BT_ATT_ERROR_AUTHENTICATION ||
+		    att_ecode == BT_ATT_ERROR_INSUFFICIENT_ENCRYPTION) {
+			/*
+			 * Link not yet encrypted. The retry is handled
+			 * by rap_idle() after pairing completes.
+			 */
+			DBG(rap, "RAS Features requires security "
+				"(error 0x%02x)"
+			    " - retry will be scheduled by idle handler",
+			    att_ecode);
+		} else {
+			DBG(rap, "Unable to read RAS Features: error 0x%02x",
+			    att_ecode);
+		}
+		return;
+	}
+
+	ras = rap_get_ras(rap);
+	if (ras) {
+		ras->features_read_pending = false;
+		ras->features_read_success = true;
+	}
+
+	if (length == 0 || length > 4) {
+		DBG(rap, "Invalid RAS Features length: %u (expected 1-4)",
+			length);
+		return;
+	}
+
+	/* RAS Features is a 4-byte little-endian value.
+	 * Some devices send fewer bytes (e.g. 1 byte); zero-pad to 4 bytes.
+	 */
+	if (length < 4) {
+		uint8_t padded[4] = { 0, 0, 0, 0 };
+
+		memcpy(padded, value, length);
+		iov.iov_base = padded;
+		iov.iov_len = 4;
+		DBG(rap, "RAS Features: short read (%u bytes), zero-pad to 4",
+		    length);
+	}
+
+	if (!util_iov_pull_le32(&iov, &features)) {
+		DBG(rap, "Unable to parse RAS Features value");
+		return;
+	}
+
+	DBG(rap, "RAS Features: 0x%08x", features);
+
+	/* Parse feature bits according to RAS specification:
+	 * Bit 0: Real-time ranging data
+	 * Bit 1: Retrieve stored results (on-demand)
+	 * Bit 2: Abort operation
+	 * Bits 3-31: Reserved for future use
+	 */
+	supports_realtime = (features & 0x01) != 0;
+	supports_ondemand = (features & 0x02) != 0;
+	supports_abort    = (features & 0x04) != 0;
+
+	DBG(rap, "RAS Features - Real-time: %s, On-demand: %s, Abort: %s",
+	    supports_realtime ? "Yes" : "No",
+	    supports_ondemand ? "Yes" : "No",
+	    supports_abort    ? "Yes" : "No");
+
+	DBG(rap, "RAS features read successfully, capabilities determined");
+
+	/* Register for real-time characteristic notifications if supported */
+	if (supports_realtime && ras && ras->realtime_chrc && rap->client) {
+		uint16_t value_handle;
+		bt_uuid_t uuid;
+
+		if (gatt_db_attribute_get_char_data(ras->realtime_chrc,
+					NULL, &value_handle,
+					NULL, NULL, &uuid)) {
+			unsigned int notify_id;
+
+			notify_id = bt_rap_register_notify(rap,
+						value_handle,
+						ras_realtime_notify_cb,
+						NULL);
+			if (!notify_id) {
+				DBG(rap, "Failed to register for "
+					"real-time notifications");
+			} else {
+				DBG(rap, "Registered for real-time "
+					"notifications based on "
+					"features: id=%u",
+				    notify_id);
+			}
+		}
+	} else if (!supports_realtime) {
+		DBG(rap, "Real-time ranging not supported by "
+			"remote device - skipping notification "
+			"registration");
+	}
 }
 
 static void foreach_rap_char(struct gatt_db_attribute *attr, void *user_data)
@@ -1848,6 +3365,16 @@ static void foreach_rap_char(struct gatt_db_attribute *attr, void *user_data)
 			return;
 
 		ras->feat_chrc = attr;
+		/* Cache handle for potential security-upgrade retry */
+		ras->features_handle = value_handle;
+		ras->features_read_pending = false;
+
+		/* Read features from remote server to determine capabilities */
+		if (rap->client) {
+			rap_read_value(rap, value_handle,
+					read_ras_features, rap);
+			DBG(rap, "Reading RAS features from remote server");
+		}
 	}
 
 	if (!bt_uuid_cmp(&uuid, &uuid_realtime)) {
@@ -1992,8 +3519,27 @@ static void rap_notify_ready(struct bt_rap *rap)
 static void rap_idle(void *data)
 {
 	struct bt_rap *rap = data;
+	struct ras *ras;
 
 	rap->idle_id = 0;
+	/*
+	 * Retry the RAS Features read if it hasn't succeeded yet.
+	 * This handles the case where the initial read failed because
+	 * the link was not yet encrypted (pairing was in progress).
+	 * After pairing completes the GATT client becomes idle again,
+	 * giving us a second chance to read the features value.
+	 */
+	if (rap->client) {
+		ras = rap_get_ras(rap);
+		if (ras && ras->features_handle &&
+		    !ras->features_read_success &&
+		    !ras->features_read_pending) {
+			DBG(rap, "Retrying RAS Features read after GATT idle");
+			ras->features_read_pending = true;
+			rap_read_value(rap, ras->features_handle,
+				       read_ras_features, rap);
+		}
+	}
 	rap_notify_ready(rap);
 }
 

--- a/src/shared/rap.h
+++ b/src/shared/rap.h
@@ -12,6 +12,7 @@
 #include "bluetooth/mgmt.h"
 #include "src/shared/hci.h"
 
+struct bcs_procedure_data;
 struct bt_rap;
 struct gatt_db;
 struct bt_gatt_client;
@@ -162,6 +163,9 @@ typedef void (*bt_rap_ready_func_t)(struct bt_rap *rap, void *user_data);
 typedef void (*bt_rap_destroy_func_t)(void *user_data);
 typedef void (*bt_rap_func_t)(struct bt_rap *rap, void *user_data);
 
+typedef void (*bt_rap_procedure_data_func_t)(struct bt_rap *rap,
+				const struct bcs_procedure_data *bcs,
+				void *user_data);
 struct bt_rap *bt_rap_ref(struct bt_rap *rap);
 void bt_rap_unref(struct bt_rap *rap);
 
@@ -176,6 +180,10 @@ bool bt_rap_set_user_data(struct bt_rap *rap, void *user_data);
 
 bool bt_rap_set_debug(struct bt_rap *rap, bt_rap_debug_func_t func,
 			void *user_data, bt_rap_destroy_func_t destroy);
+bool bt_rap_set_procedure_data_cb(struct bt_rap *rap,
+				  bt_rap_procedure_data_func_t cb,
+				  void *user_data,
+				  bt_rap_destroy_func_t destroy);
 
 /* session related functions */
 unsigned int bt_rap_register(bt_rap_func_t attached, bt_rap_func_t detached,


### PR DESCRIPTION
Add bcs_util.c/h with helpers to parse and copy Channel Sounding (CS) procedure step data (modes 0–3), aggregate subevent results into a bcs_procedure_data structure, and compute timing/duration metadata.

Extend bt_rap to accumulate ranging data segments from the remote RAS server, reassemble them into per-procedure BCS structures, and deliver them to callers via a new bt_rap_set_procedure_data_cb() API.

Add RAS status/abort unpack macros, antenna mask helpers, and features handle caching needed to drive the client-side flow.