### PR TITLE
bass: allocate subgroup_data for all subgroups in bass_build_bcast_src

### DIFF
--- a/src/shared/bass.c
+++ b/src/shared/bass.c
@@ -334,7 +334,7 @@ static int bass_build_bcast_src(struct bt_bcast_src *bcast_src,
 	if (num_subgroups == 0)
 		goto done;
 
-	subgroup_data = new0(struct bt_bass_subgroup_data, 1);
+	subgroup_data = new0(struct bt_bass_subgroup_data, num_subgroups);
 	if (!subgroup_data) {
 		DBG(bcast_src->bass, "Unable to allocate memory");
 		return -1;


### PR DESCRIPTION
bass_build_bcast_src allocates subgroup_data with new0(..., 1) but then loops num_subgroups times writing each entry. num_subgroups is an attacker-controlled byte from the Broadcast Receive State characteristic value received over GATT, so any value above one writes past the single-element heap allocation. Allocate num_subgroups entries up front, matching the allocation already used when building a source from local Add Source parameters.