### PR TITLE
avrcp: validate name length when parsing browsed media items

### DIFF
--- a/profiles/audio/avrcp.c
+++ b/profiles/audio/avrcp.c
@@ -2601,6 +2601,8 @@ static struct media_item *parse_media_element(struct avrcp *session,
 
 	memset(name, 0, sizeof(name));
 	namesize = get_be16(&operands[11]);
+	if (len < namesize + 14)
+		return NULL;
 	namelen = MIN(namesize, sizeof(name) - 1);
 	if (namelen > 0) {
 		memcpy(name, &operands[13], namelen);
@@ -2630,7 +2632,7 @@ static struct media_item *parse_media_folder(struct avrcp *session,
 	struct avrcp_player *player = session->controller->player;
 	struct media_player *mp = player->user_data;
 	struct media_item *item;
-	uint16_t namelen;
+	uint16_t namelen, namesize;
 	char name[255];
 	uint64_t uid;
 	uint8_t type;
@@ -2644,7 +2646,10 @@ static struct media_item *parse_media_folder(struct avrcp *session,
 	playable = operands[9];
 
 	memset(name, 0, sizeof(name));
-	namelen = MIN(get_be16(&operands[12]), sizeof(name) - 1);
+	namesize = get_be16(&operands[12]);
+	if (len < namesize + 14)
+		return NULL;
+	namelen = MIN(namesize, sizeof(name) - 1);
 	if (namelen > 0)
 		memcpy(name, &operands[14], namelen);
 


### PR DESCRIPTION
Reading through the GetFolderItems browsing response handler I noticed parse_media_element and parse_media_folder pull a 16-bit name length out of the remote target's PDU and use it without checking it against the item length, so a target advertising a short item with a large name field walks the name memcpy, the count byte and the attribute pointer well past the received buffer. Reject items where len is smaller than the declared name plus header, matching the namelen + 28 == len guard the addressed-player parser already uses.