### PR TITLE
gatt: validate data_length when parsing read-by-type response

### DIFF
--- a/src/shared/gatt-helpers.c
+++ b/src/shared/gatt-helpers.c
@@ -1306,7 +1306,8 @@ static void read_by_type_cb(uint8_t opcode, const void *pdu,
 	}
 
 	data_length = ((uint8_t *) pdu)[0];
-	if (((length - 1) % data_length)) {
+	if (data_length < 2 || (length - 1) < data_length ||
+					((length - 1) % data_length)) {
 		success = false;
 		att_ecode = 0;
 		goto done;


### PR DESCRIPTION
**Out-of-bounds read parsing a read-by-type response**

read_by_type_cb lifts the per-record length byte straight out of the remote server's PDU and never checks it, so a target returning a two-byte response or a zero length sends get_le16 off the front of the buffer and stores a data_len below two, which the iterator later turns into data_len - 2 and hands the caller a value length near 64KB. The other discovery parsers in this file already bound that length against the PDU before touching it, so I've added the same check here rather than leaning on the callers to sanitise.