### PR TITLE
bap: bound channel allocation ltv copy to avoid stack overflow

### DIFF
--- a/src/shared/bap.c
+++ b/src/shared/bap.c
@@ -2545,12 +2545,12 @@ static unsigned int bap_bcast_sink_get_dir(struct bt_bap_stream *stream)
 static void bap_sink_get_allocation(size_t i, uint8_t l, uint8_t t,
 		uint8_t *v, void *user_data)
 {
-	uint32_t location32;
+	uint32_t location32 = 0;
 
 	if (!v)
 		return;
 
-	memcpy(&location32, v, l);
+	memcpy(&location32, v, MIN(l, sizeof(location32)));
 	*((uint32_t *)user_data) = le32_to_cpu(location32);
 }
 
@@ -7533,12 +7533,12 @@ static void bap_sink_match_allocation(size_t i, uint8_t l, uint8_t t,
 		uint8_t *v, void *user_data)
 {
 	struct bt_ltv_match *data = user_data;
-	uint32_t location32;
+	uint32_t location32 = 0;
 
 	if (!v)
 		return;
 
-	memcpy(&location32, v, l);
+	memcpy(&location32, v, MIN(l, sizeof(location32)));
 	location32 = le32_to_cpu(location32);
 
 	/* If all the bits in the received bitmask are found in


### PR DESCRIPTION
Found this tracing how a scanned broadcast source's BASE reaches the LTV parsers. `bt_bap_parse_base()` hands the codec-specific configuration from the BIG Info report straight into `util_ltv_foreach`, so the LTV length byte is whatever the broadcaster put on air and nothing in between clamps it.

1. `bap_sink_match_allocation` and `bap_sink_get_allocation` are allocation-LTV callbacks that `memcpy(&location32, v, l)` into a 4-byte `uint32_t`.
2. `l` is the remote LTV value length and runs up to 254, so any Channel_Allocation LTV with a length above 5 overruns `location32` on the stack.
3. Bounded both copies to `sizeof(location32)` and zero-initialised the destination so a short LTV leaves no stale bytes behind.

ASan reports a 250-byte stack-buffer-overflow write at the memcpy when the length byte is set to 0xFB. The trigger sits on the broadcast scan path, well before any pairing, so an unfixed scanner can have its stack smashed by a hostile broadcaster it merely syncs to.
