### PR TITLE
hostname: Update adapter name on transient hostname change

### DIFF
--- a/plugins/hostname.c
+++ b/plugins/hostname.c
@@ -210,6 +210,7 @@ static gboolean hostname_cb(GIOChannel *io, GIOCondition cond,
 {
 	DBG("transient hostname changed");
 	read_transient_hostname();
+	btd_adapter_foreach(update_name, NULL);
 	btd_adapter_foreach(update_class, NULL);
 	return TRUE;
 }


### PR DESCRIPTION
When the kernel (transient) hostname changes, BlueZ is notified via the G_IO_ERR watch on /proc/sys/kernel/hostname and hostname_cb() re-reads it through read_transient_hostname(). However the callback only refreshed the adapter class via update_class(), so the advertised adapter name was never updated to follow the new hostname.

Also propagate the change to the adapter name via update_name() so that a hostname set dynamically (e.g. through sethostname()) is reflected in the adapter name without needing to restart the daemon.