### PR TITLE
monitor: Fix ATT opcode table bounds checks

### DIFF
--- a/monitor/att.c
+++ b/monitor/att.c
@@ -1815,7 +1815,7 @@ static const struct ase_cmd {
 
 static const struct ase_cmd *ase_get_cmd(uint8_t op)
 {
-	if (op > ARRAY_SIZE(ase_cmd_table))
+	if (op >= ARRAY_SIZE(ase_cmd_table))
 		return NULL;
 
 	return &ase_cmd_table[op];
@@ -2264,7 +2264,7 @@ static const struct vcs_cmd {
 
 static const struct vcs_cmd *vcs_get_cmd(uint8_t op)
 {
-	if (op > ARRAY_SIZE(vcs_cmd_table))
+	if (op >= ARRAY_SIZE(vcs_cmd_table))
 		return NULL;
 
 	return &vcs_cmd_table[op];
@@ -3907,7 +3907,7 @@ static const struct bcast_audio_scan_cp_cmd {
 static const struct bcast_audio_scan_cp_cmd *
 bcast_audio_scan_cp_get_cmd(uint8_t op)
 {
-	if (op > ARRAY_SIZE(bcast_audio_scan_cp_cmd_table))
+	if (op >= ARRAY_SIZE(bcast_audio_scan_cp_cmd_table))
 		return NULL;
 
 	return &bcast_audio_scan_cp_cmd_table[op];
@@ -4821,7 +4821,7 @@ static const struct ras_cmd {
 
 static const struct ras_cmd *ras_get_cmd(uint8_t op)
 {
-	if (op > ARRAY_SIZE(ras_cmd_table))
+	if (op >= ARRAY_SIZE(ras_cmd_table))
 		return NULL;
 
 	return &ras_cmd_table[op];


### PR DESCRIPTION
Summary:
- Reject `op == ARRAY_SIZE(...)` before indexing ATT monitor opcode tables.
- Cover ASE, VCS, Broadcast Audio Scan Control Point, and RAS command lookup helpers.

Testing:
- `git diff origin/master --check`
- `rg -n "if \(op > ARRAY_SIZE\([^)]*cmd_table\)\)" monitor\att.c` (no matches)
- `git ls-files --eol monitor\att.c`

Not run:
- Build tests, because this Windows environment does not have Meson, Ninja, GCC, or Clang installed.
