### PR TITLE
monitor: harden EIR field payload parsing

### DIFF
--- a/monitor/packet.c
+++ b/monitor/packet.c
@@ -4097,6 +4097,8 @@ static void print_eir(const char *label, const uint8_t *eir, uint8_t eir_len,
 
 		switch (eir[1]) {
 		case BT_EIR_FLAGS:
+			if (data_len < 1)
+				break;
 			flags = *data;
 
 			print_field("Flags: 0x%2.2x", flags);
@@ -4151,13 +4153,13 @@ static void print_eir(const char *label, const uint8_t *eir, uint8_t eir_len,
 
 		case BT_EIR_NAME_SHORT:
 			memset(name, 0, sizeof(name));
-			memcpy(name, data, data_len);
+			memcpy(name, data, MIN(data_len, sizeof(name) - 1));
 			print_field("Name (short): %s", name);
 			break;
 
 		case BT_EIR_NAME_COMPLETE:
 			memset(name, 0, sizeof(name));
-			memcpy(name, data, data_len);
+			memcpy(name, data, MIN(data_len, sizeof(name) - 1));
 			print_field("Name (complete): %s", name);
 			break;
 
@@ -4194,6 +4196,8 @@ static void print_eir(const char *label, const uint8_t *eir, uint8_t eir_len,
 			break;
 
 		case BT_EIR_SMP_OOB_FLAGS:
+			if (data_len < 1)
+				break;
 			print_field("SMP OOB Flags: 0x%2.2x", *data);
 			break;
 
@@ -4311,7 +4315,7 @@ static void print_eir(const char *label, const uint8_t *eir, uint8_t eir_len,
 
 		case BT_EIR_BC_NAME:
 			memset(name, 0, sizeof(name));
-			memcpy(name, data, data_len);
+			memcpy(name, data, MIN(data_len, sizeof(name) - 1));
 			print_field("Broadcast Name: %s", name);
 			break;
 


### PR DESCRIPTION
The EIR parser validates that an AD structure fits in the input buffer before dispatching it, but individual decoders still need to validate the payload bytes they consume.

This hardens the fixed-size EIR decoders in `print_eir()` by:
- checking that `BT_EIR_FLAGS` has a byte before reading `*data`
- checking that `BT_EIR_SMP_OOB_FLAGS` has a byte before reading `*data`
- capping short, complete, and broadcast name copies to the fixed-size stack buffer while leaving room for the terminating NUL

Validation:
- `git diff --check HEAD~1..HEAD`
- `git ls-files --eol monitor/packet.c`
- Static review that remaining `flags = *data` in `BT_EIR_3D_INFO_DATA` is guarded by `data_len < 2`

A local build was not run because this environment does not have Meson/Ninja/GCC installed.
