### PR TITLE
eir: bound remote name length to the local buffer in name2utf8

### DIFF
--- a/src/eir.c
+++ b/src/eir.c
@@ -137,6 +137,8 @@ static char *name2utf8(const uint8_t *name, uint8_t len)
 {
 	char utf8_name[HCI_MAX_NAME_LENGTH + 2];
 
+	len = MIN(len, HCI_MAX_NAME_LENGTH);
+
 	memset(utf8_name, 0, sizeof(utf8_name));
 	strncpy(utf8_name, (char *) name, len);
 	strtoutf8(utf8_name, len);

--- a/src/shared/ad.c
+++ b/src/shared/ad.c
@@ -276,15 +276,15 @@ static bool ad_replace_uuid128(struct bt_ad *ad, struct iovec *iov)
 static bool ad_replace_name(struct bt_ad *ad, struct iovec *iov)
 {
 	char utf8_name[HCI_MAX_NAME_LENGTH + 2];
+	size_t len = MIN(iov->iov_len, HCI_MAX_NAME_LENGTH);
 
 	memset(utf8_name, 0, sizeof(utf8_name));
-	strncpy(utf8_name, (const char *)iov->iov_base,
-			MIN(iov->iov_len, HCI_MAX_NAME_LENGTH));
+	strncpy(utf8_name, (const char *)iov->iov_base, len);
 
-	if (strisutf8(utf8_name, iov->iov_len))
+	if (strisutf8(utf8_name, len))
 		goto done;
 
-	strtoutf8(utf8_name, iov->iov_len);
+	strtoutf8(utf8_name, len);
 
 	/* Remove leading and trailing whitespace characters */
 	strstrip(utf8_name);

--- a/unit/test-eir.c
+++ b/unit/test-eir.c
@@ -577,6 +577,38 @@ static void test_basic(const void *data)
 	tester_test_passed();
 }
 
+static void test_oversized_name(const void *data)
+{
+	/* Longest name a remote peer can put in a single AD structure:
+	 * length 0xfe, type 0x09 and 253 payload bytes which are neither
+	 * NUL terminated nor valid UTF-8.
+	 */
+	unsigned char buf[2 + 253];
+	char expected[HCI_MAX_NAME_LENGTH + 1];
+	struct eir_data eir;
+	struct bt_ad *ad;
+
+	buf[0] = sizeof(buf) - 1;
+	buf[1] = EIR_NAME_COMPLETE;
+	memset(buf + 2, 'A', sizeof(buf) - 3);
+	buf[sizeof(buf) - 1] = 0xff;
+
+	memset(expected, 'A', sizeof(expected) - 1);
+	expected[sizeof(expected) - 1] = '\0';
+
+	memset(&eir, 0, sizeof(eir));
+	eir_parse(&eir, buf, sizeof(buf));
+	g_assert_cmpstr(eir.name, ==, expected);
+	eir_data_free(&eir);
+
+	ad = bt_ad_new_with_data(sizeof(buf), buf);
+	g_assert(ad);
+	g_assert_cmpstr(bt_ad_get_name(ad), ==, expected);
+	bt_ad_unref(ad);
+
+	tester_test_passed();
+}
+
 static void print_debug(const char *str, void *user_data)
 {
 	char *prefix = user_data;
@@ -740,6 +772,8 @@ int main(int argc, char *argv[])
 	tester_init(&argc, &argv);
 
 	tester_add("/eir/basic", NULL, NULL, test_basic, NULL);
+	tester_add("/eir/oversized-name", NULL, NULL, test_oversized_name,
+									NULL);
 
 	tester_add("/eir/macbookair", &macbookair_test, NULL, test_parsing,
 									NULL);


### PR DESCRIPTION
**Stack overflow on the discovery path from an oversized EIR/AD name**

`eir_parse()` hands `name2utf8()` a `data_len` of up to 253 (`field_len` can be 254), and `bt_ad_parse_data()` hands `ad_replace_name()` an `iov_len` of up to 253 the same way, but `utf8_name` is `HCI_MAX_NAME_LENGTH + 2` = 250 bytes; a peer advertising a name with no NUL terminator walks off the end during `strncpy()`, and `strisutf8()`/`strtoutf8()` read and write past it too. Clamped both to `HCI_MAX_NAME_LENGTH` like `gas.c` already does, with a regression case in `unit/test-eir.c` that hits both parsers.