### PR TITLE
client: Handle system bus setup failure

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -4017,6 +4017,7 @@ static bool timeout_quit(void *user_data)
 int main(int argc, char *argv[])
 {
 	GDBusClient *client;
+	DBusError error;
 	int status;
 	int timeout;
 	unsigned int timeout_id;
@@ -4048,7 +4049,18 @@ int main(int argc, char *argv[])
 	else
 		auto_register_agent = g_strdup("");
 
-	dbus_conn = g_dbus_setup_bus(DBUS_BUS_SYSTEM, NULL, NULL);
+	dbus_error_init(&error);
+	dbus_conn = g_dbus_setup_bus(DBUS_BUS_SYSTEM, NULL, &error);
+	if (!dbus_conn) {
+		if (dbus_error_is_set(&error)) {
+			g_printerr("D-Bus setup failed: %s\n", error.message);
+			dbus_error_free(&error);
+		}
+
+		g_free(auto_register_agent);
+		return EXIT_FAILURE;
+	}
+
 	g_dbus_attach_object_manager(dbus_conn);
 
 	bt_shell_set_env("DBUS_CONNECTION", dbus_conn);


### PR DESCRIPTION
bluetoothctl assumes that g_dbus_setup_bus always succeeds and passes
the result directly to g_dbus_attach_object_manager. When the system bus
is unavailable, g_dbus_setup_bus returns NULL and libdbus aborts on the
invalid connection argument.

Request the underlying DBusError, report it to the user, and return
EXIT_FAILURE before using the connection.

Reproducer:

    DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/no-such-bus \
        bluetoothctl devices Connected

Before this change, the command terminates with SIGABRT in
dbus_connection_get_object_path_data. Afterward, it prints the D-Bus
connection error and exits with status 1.

Testing:

- make -j2 client/bluetoothctl
- make -j2 check (34 tests passed)
- denied-bus reproducer exits 1 without a core dump
- live system-bus bluetoothctl devices Connected smoke test exits 0
