### PR TITLE
input: retry HOG GATT reads on ATT Unlikely Error (0x0E)

### DIFF
--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -71,6 +71,9 @@
 #define HID_INFO_SIZE			4
 #define ATT_NOTIFICATION_HEADER_SIZE	3
 
+#define HOG_GATT_RETRY_MAX		3
+#define HOG_GATT_RETRY_DELAY_MS		200
+
 struct bt_hog {
 	int			ref_count;
 	char			*name;
@@ -124,6 +127,10 @@ struct gatt_request {
 	unsigned int id;
 	struct bt_hog *hog;
 	void *user_data;
+	uint16_t handle;
+	GAttribResultFunc func;
+	uint8_t retry_count;
+	guint retry_timer;
 };
 
 static struct gatt_request *create_request(struct bt_hog *hog,
@@ -153,11 +160,17 @@ static void destroy_gatt_req(void *data)
 {
 	struct gatt_request *req = data;
 
+	if (req->retry_timer) {
+		g_source_remove(req->retry_timer);
+		req->retry_timer = 0;
+	}
+
 	bt_hog_unref(req->hog);
 	free(req);
 }
 
 static void read_report_map(struct bt_hog *hog);
+static gboolean retry_gatt_read(gpointer user_data);
 static void sci_mode_read_cb(guint8 status, const guint8 *pdu, guint16 plen,
 							gpointer user_data);
 static void sci_info_read_cb(guint8 status, const guint8 *pdu, guint16 plen,
@@ -169,6 +182,22 @@ static void remove_gatt_req(struct gatt_request *req, uint8_t status)
 
 	queue_remove(hog->gatt_op, req);
 
+	/* Retry on ATT Unlikely Error (0x0E) - peripheral GATT server may
+	 * not be ready yet after waking from deep sleep.  Schedule a delayed
+	 * retry instead of giving up immediately.
+	 */
+	if (status == ATT_ECODE_UNLIKELY &&
+			req->retry_count < HOG_GATT_RETRY_MAX &&
+			req->func && hog->attrib) {
+		req->retry_count++;
+		DBG("hog: GATT retry %d/%d for handle 0x%04x",
+				req->retry_count, HOG_GATT_RETRY_MAX,
+				req->handle);
+		req->retry_timer = g_timeout_add(HOG_GATT_RETRY_DELAY_MS,
+						retry_gatt_read, req);
+		return;
+	}
+
 	if (!status && queue_isempty(hog->gatt_op)) {
 		/* Report Map must be read last since that can result
 		 * in uhid being created and the driver may start to
@@ -179,6 +208,37 @@ static void remove_gatt_req(struct gatt_request *req, uint8_t status)
 	}
 
 	destroy_gatt_req(req);
+}
+
+static gboolean retry_gatt_read(gpointer user_data)
+{
+	struct gatt_request *req = user_data;
+	struct bt_hog *hog = req->hog;
+	unsigned int id;
+
+	req->retry_timer = 0;
+
+	if (!hog->attrib) {
+		DBG("hog: Retry cancelled, device detached");
+		destroy_gatt_req(req);
+		return FALSE;
+	}
+
+	id = gatt_read_char(hog->attrib, req->handle, req->func, req);
+	if (!id) {
+		error("hog: GATT retry failed to queue read");
+		destroy_gatt_req(req);
+		return FALSE;
+	}
+
+	if (!set_and_store_gatt_req(hog, req, id)) {
+		error("hog: Failed to queue GATT retry");
+		g_attrib_cancel(hog->attrib, id);
+		destroy_gatt_req(req);
+		return FALSE;
+	}
+
+	return FALSE;
 }
 
 static void write_char(struct bt_hog *hog, GAttrib *attrib, uint16_t handle,
@@ -216,6 +276,9 @@ static unsigned int read_char(struct bt_hog *hog, GAttrib *attrib,
 	req = create_request(hog, user_data);
 	if (!req)
 		return 0;
+
+	req->handle = handle;
+	req->func = func;
 
 	id = gatt_read_char(attrib, handle, func, req);
 	if (!id) {


### PR DESCRIPTION
## Summary

`profiles/input/hog-lib.c`'s `remove_gatt_req()` treats every GATT read
failure as permanent, including ATT error `0x0E` ("Unlikely Error"). A
peripheral's GATT server can return this transiently right after it
becomes reachable again, and if it happens during HOG setup,
`read_report_map()` is never reached and the device is left
half-initialized.

This retries each read up to 3 times, 200ms apart, specifically on
`ATT_ECODE_UNLIKELY`. Any other error status keeps today's behavior
(permanent, no retry).

## Background

Originally reported and patched in #1911 (closed stale by the bot, not on
a maintainer decision) against 5.82. That issue has since accumulated
three independent confirmations on unrelated hardware:

- A different BLE mouse (Logitech Lift), BlueZ 5.85, Realtek adapter.
- An Xbox Wireless Controller, BlueZ 5.86, Realtek adapter.
- My own case: BlueZ 5.83, a BLE smartwatch whose *unrelated*
  HID-over-GATT service triggers this same code path on every connection
  while the host isn't bonded for that specific service — so the failure
  recurs continuously rather than once per session.

I rebased the original patch onto current master, which added a
`set_and_store_gatt_req()` helper that didn't exist when it was written;
the retry path now reuses it instead of duplicating its logic.

Closes #1911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)