### PR TITLE
adapter/advertising: fix missing byte-order conversion for several mgmt fields for big endian cpu

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -10206,10 +10206,11 @@ static bool set_blocked_keys(struct btd_adapter *adapter)
 					sizeof(blocked_keys)] = { 0 };
 	struct mgmt_cp_set_blocked_keys *cp =
 				(struct mgmt_cp_set_blocked_keys *)buffer;
+	const uint16_t key_count = ARRAY_SIZE(blocked_keys);
 	int i;
 
-	cp->key_count = ARRAY_SIZE(blocked_keys);
-	for (i = 0; i < cp->key_count; ++i) {
+	cp->key_count = htobs(key_count);
+	for (i = 0; i < key_count; ++i) {
 		cp->keys[i].type = blocked_keys[i].type;
 		memcpy(cp->keys[i].val, blocked_keys[i].val,
 						sizeof(cp->keys[i].val));

--- a/src/advertising.c
+++ b/src/advertising.c
@@ -1042,7 +1042,7 @@ static int refresh_legacy_adv(struct btd_adv_client *client,
 
 	cp->flags = htobl(flags);
 	cp->instance = client->instance;
-	cp->duration = client->duration;
+	cp->duration = htobs(client->duration);
 	cp->adv_data_len = adv_data_len;
 	cp->scan_rsp_len = scan_rsp_len;
 	memcpy(cp->data, adv_data, adv_data_len);
@@ -1093,13 +1093,13 @@ static int refresh_extended_adv(struct btd_adv_client *client,
 	 */
 
 	if (client->duration) {
-		cp.duration = client->duration;
+		cp.duration = htobs(client->duration);
 		flags |= MGMT_ADV_PARAM_DURATION;
 	}
 
 	if (client->min_interval && client->max_interval) {
-		cp.min_interval = client->min_interval;
-		cp.max_interval = client->max_interval;
+		cp.min_interval = htobl(client->min_interval);
+		cp.max_interval = htobl(client->max_interval);
 		flags |= MGMT_ADV_PARAM_INTERVALS;
 	}
 


### PR DESCRIPTION
Several places in adapter.c and advertising.c write a native-endian value directly into a __le16/__le32 field of an mgmt command struct, skipping the htobs()/htobl() conversion used everywhere else in this codebase for the same purpose. This is a no-op on little-endian hosts (where htobs()/htobl() are themselves no-ops), which is why it has gone unnoticed, but corrupts the value on big-endian hosts.

Confirmed live on MIPS big-endian (OpenWrt/ath79): set_blocked_keys() sends key_count=2 (2 blocked keys), which the kernel's __le16_to_cpu() correctly interprets as 512 (0x0002 byte-swapped is 0x0200) since the wire bytes were never actually swapped to little- endian on the way out -- producing "expected 8706 bytes, got 36 bytes" / "Failed to set blocked keys: Invalid Parameters" errors in dmesg/bluetoothd logs.

add_advertising()'s cp->duration and refresh_extended_adv()'s cp.duration/cp.min_interval/cp.max_interval have the identical bug. It is inert with bluetoothctl's default (0) duration/interval values (0 byte-swapped is still 0), but A/B tested live (patch removed vs. applied, bluetoothctl's advertise submenu "interval 100 100" set explicitly) confirms this is not just a theoretical correctness fix: with the bug present, the device stops being discoverable by a real BLE scanner the moment a non-default interval is requested, and becomes discoverable again immediately once patched. Any application that sets an explicit advertising interval or duration hits this.