### PR TITLE
Fix Pebble K380s multi-host reconnect on 0a12:0001 adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ cscope.out
 cscope.po.out
 
 **/__pycache__
+/pebble-trace.log

--- a/INSTALL
+++ b/INSTALL
@@ -234,3 +234,4 @@ configuration-related scripts to be executed by `/bin/bash'.
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.
 
+

--- a/PEBBLE_DEBUG.md
+++ b/PEBBLE_DEBUG.md
@@ -1,0 +1,25 @@
+# Pebble K380s reconnect investigation
+
+Target device: Logitech Pebble K380s (`046d:b377`), Bluetooth address
+`D2:92:89:C7:3A:ED` during the current pairing.
+
+Symptom: after switching the keyboard to another Easy-Switch host and back,
+BlueZ reports `Connected: yes` and exposes a UHID input node, but no key events
+arrive. Resetting the USB Bluetooth adapter restores input.
+
+The instrumentation in `profiles/input/hog-lib.c` records:
+
+- HoG attach and rejected duplicate attach attempts;
+- HoG detach and whether it is forced;
+- CCC notification enablement;
+- notification handler registration and removal;
+- incoming HID report notifications.
+
+## Capture protocol
+
+1. Start `tools/capture-pebble-trace.sh`.
+2. Reset the adapter and type several keys (known-good baseline).
+3. Switch to another Easy-Switch channel for at least five seconds.
+4. Switch back and type several keys (failing path).
+5. Reset the adapter and type again (recovery baseline).
+6. Stop capture with Ctrl+C.

--- a/PEBBLE_DEBUG.md
+++ b/PEBBLE_DEBUG.md
@@ -39,6 +39,7 @@ Bluetooth devices.
 
 Re-arming the kernel auto-connect entry alone did not make the `0a12:0001`
 controller resume useful LE scanning. Because a USB reset is known to recover
-the device, the Pebble-specific disconnect path now schedules `/usr/bin/usbreset
-0a12:0001` after one second. It runs outside the disconnect callback to avoid
-re-entrant adapter teardown. A pending guard prevents duplicate reset jobs.
+the device, the Pebble-specific disconnect path now schedules
+`/usr/bin/usbreset 0a12:0001` after 100 milliseconds. It runs outside the
+disconnect callback to avoid re-entrant adapter teardown. A pending guard
+prevents duplicate reset jobs.

--- a/PEBBLE_DEBUG.md
+++ b/PEBBLE_DEBUG.md
@@ -40,6 +40,13 @@ Bluetooth devices.
 Re-arming the kernel auto-connect entry alone did not make the `0a12:0001`
 controller resume useful LE scanning. Because a USB reset is known to recover
 the device, the Pebble-specific disconnect path now schedules
-`/usr/bin/usbreset 0a12:0001` after 100 milliseconds. It runs outside the
+`/usr/bin/usbreset 0a12:0001` after 1 millisecond. It runs outside the
 disconnect callback to avoid re-entrant adapter teardown. A pending guard
 prevents duplicate reset jobs.
+
+## Latency tuning
+
+The fork uses a continuous 10 ms LE scan window for auto-connect and connection
+establishment. This favors reconnection latency over adapter power consumption;
+the target is a mains-powered desktop. The deferred USB reset delay is reduced
+to 1 ms, which still keeps adapter teardown outside the disconnect callback.

--- a/PEBBLE_DEBUG.md
+++ b/PEBBLE_DEBUG.md
@@ -23,3 +23,14 @@ The instrumentation in `profiles/input/hog-lib.c` records:
 4. Switch back and type several keys (failing path).
 5. Reset the adapter and type again (recovery baseline).
 6. Stop capture with Ctrl+C.
+
+## Experimental fix 1
+
+The first capture showed a clean forced HoG detach when the keyboard left its
+Linux Easy-Switch channel. No subsequent HoG attach occurred until the USB
+adapter reset, at which point CCC subscriptions and input reports were restored.
+
+For `046d:b377`, `device_remove_connection()` now removes and re-adds the device
+to the kernel auto-connect list after an LE disconnect. This re-arms controller
+background scanning without resetting the adapter or disturbing unrelated
+Bluetooth devices.

--- a/PEBBLE_DEBUG.md
+++ b/PEBBLE_DEBUG.md
@@ -34,3 +34,11 @@ For `046d:b377`, `device_remove_connection()` now removes and re-adds the device
 to the kernel auto-connect list after an LE disconnect. This re-arms controller
 background scanning without resetting the adapter or disturbing unrelated
 Bluetooth devices.
+
+## Experimental fix 2
+
+Re-arming the kernel auto-connect entry alone did not make the `0a12:0001`
+controller resume useful LE scanning. Because a USB reset is known to recover
+the device, the Pebble-specific disconnect path now schedules `/usr/bin/usbreset
+0a12:0001` after one second. It runs outside the disconnect callback to avoid
+re-entrant adapter teardown. A pending guard prevents duplicate reset jobs.

--- a/profiles/input/hog-lib.c
+++ b/profiles/input/hog-lib.c
@@ -100,6 +100,11 @@ struct bt_hog {
 	struct gatt_db_attribute	*report_map_attr;
 };
 
+static bool is_pebble_k380s(const struct bt_hog *hog)
+{
+	return hog && hog->vendor == 0x046d && hog->product == 0xb377;
+}
+
 struct report {
 	struct bt_hog		*hog;
 	bool			numbered;
@@ -334,6 +339,12 @@ static void report_value_cb(const guint8 *pdu, guint16 len, gpointer user_data)
 	pdu += ATT_NOTIFICATION_HEADER_SIZE;
 	len -= ATT_NOTIFICATION_HEADER_SIZE;
 
+	if (is_pebble_k380s(hog))
+		info("PEBBLE_TRACE report handle=0x%04x id=0x%02x "
+				"numbered=%u len=%u notifyid=%u",
+			report->value_handle, report->id, report->numbered, len,
+			report->notifyid);
+
 	err = bt_uhid_input(hog->uhid, report->numbered ? report->id : 0, pdu,
 				len);
 	if (err < 0)
@@ -343,8 +354,12 @@ static void report_value_cb(const guint8 *pdu, guint16 len, gpointer user_data)
 static void report_notify_destroy(void *user_data)
 {
 	struct report *report = user_data;
+	struct bt_hog *hog = report->hog;
 
 	DBG("");
+	if (is_pebble_k380s(hog))
+		info("PEBBLE_TRACE notify-destroy handle=0x%04x notifyid=%u",
+			report->value_handle, report->notifyid);
 
 	report->notifyid = 0;
 }
@@ -375,6 +390,10 @@ static void report_ccc_written_cb(guint8 status, const guint8 *pdu,
 					report->value_handle);
 		goto remove;
 	}
+
+	if (is_pebble_k380s(hog))
+		info("PEBBLE_TRACE ccc-enabled handle=0x%04x notifyid=%u",
+			report->value_handle, report->notifyid);
 
 	DBG("Report characteristic descriptor written: notifications enabled");
 
@@ -1693,8 +1712,17 @@ bool bt_hog_attach(struct bt_hog *hog, void *gatt)
 {
 	GSList *l;
 
-	if (hog->attrib)
+	if (is_pebble_k380s(hog))
+		info("PEBBLE_TRACE attach begin attrib=%p uhid-created=%u reports=%u",
+			hog->attrib, bt_uhid_created(hog->uhid),
+			g_slist_length(hog->reports));
+
+	if (hog->attrib) {
+		if (is_pebble_k380s(hog))
+			info("PEBBLE_TRACE attach rejected: existing attrib=%p",
+				hog->attrib);
 		return false;
+	}
 
 	hog->attrib = g_attrib_ref(gatt);
 
@@ -1747,8 +1775,11 @@ bool bt_hog_attach(struct bt_hog *hog, void *gatt)
 					report_value_cb, r,
 					report_notify_destroy);
 		if (!r->notifyid)
-			error("Unable to register report notification: "
+				error("Unable to register report notification: "
 				"handle 0x%04x", r->value_handle);
+		else if (is_pebble_k380s(hog))
+			info("PEBBLE_TRACE reconnect-notify handle=0x%04x "
+					"notifyid=%u", r->value_handle, r->notifyid);
 	}
 
 	/* Attempt to replay get/set report messages since the driver might not
@@ -1765,6 +1796,12 @@ void bt_hog_detach(struct bt_hog *hog, bool force)
 
 	if (!hog)
 		return;
+
+	if (is_pebble_k380s(hog))
+		info("PEBBLE_TRACE detach begin force=%u attrib=%p "
+				"uhid-created=%u reports=%u", force, hog->attrib,
+				bt_uhid_created(hog->uhid),
+				g_slist_length(hog->reports));
 
 	if (!hog->attrib)
 		goto done;

--- a/src/device.c
+++ b/src/device.c
@@ -4099,7 +4099,7 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
 		 */
 		if (!pebble_usb_reset_pending) {
 			pebble_usb_reset_pending = true;
-			timeout_add(100, reset_pebble_usb_adapter, NULL, NULL);
+			timeout_add(1, reset_pebble_usb_adapter, NULL, NULL);
 		}
 	}
 

--- a/src/device.c
+++ b/src/device.c
@@ -4099,7 +4099,7 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
 		 */
 		if (!pebble_usb_reset_pending) {
 			pebble_usb_reset_pending = true;
-			timeout_add_seconds(1, reset_pebble_usb_adapter, NULL, NULL);
+			timeout_add(100, reset_pebble_usb_adapter, NULL, NULL);
 		}
 	}
 

--- a/src/device.c
+++ b/src/device.c
@@ -77,6 +77,36 @@
 
 static DBusConnection *dbus_conn = NULL;
 static unsigned service_state_cb_id;
+static bool pebble_usb_reset_pending;
+
+static bool reset_pebble_usb_adapter(void *user_data)
+{
+	char *argv[] = { "/usr/bin/usbreset", "0a12:0001", NULL };
+	GError *err = NULL;
+	int status = 0;
+	bool ok;
+
+	info("PEBBLE_TRACE resetting USB adapter 0a12:0001");
+	ok = g_spawn_sync(NULL, argv, NULL,
+			G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL,
+			NULL, NULL, NULL, NULL, &status, &err);
+	pebble_usb_reset_pending = false;
+
+	if (!ok) {
+		error("PEBBLE_TRACE USB reset spawn failed: %s", err->message);
+		g_error_free(err);
+		return false;
+	}
+
+	if (!g_spawn_check_wait_status(status, &err)) {
+		error("PEBBLE_TRACE USB reset failed: %s", err->message);
+		g_error_free(err);
+		return false;
+	}
+
+	info("PEBBLE_TRACE USB adapter reset complete");
+	return false;
+}
 
 struct btd_disconnect_data {
 	guint id;
@@ -4061,6 +4091,16 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
 								reason);
 		adapter_auto_connect_remove(device->adapter, device);
 		adapter_auto_connect_add(device->adapter, device);
+
+		/* Re-arming is insufficient on 0a12:0001: the controller only
+		 * resumes useful LE scanning after a USB-level reset. Schedule it
+		 * outside this disconnect callback so adapter teardown is not
+		 * re-entrant.
+		 */
+		if (!pebble_usb_reset_pending) {
+			pebble_usb_reset_pending = true;
+			timeout_add_seconds(1, reset_pebble_usb_adapter, NULL, NULL);
+		}
 	}
 
 	g_dbus_emit_property_changed(dbus_conn, device->path,

--- a/src/device.c
+++ b/src/device.c
@@ -4048,6 +4048,21 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
 
 	device_disconnected(device, reason);
 
+	/* Some USB controllers keep the LE background-connect entry but fail to
+	 * resume scanning after a multi-host HID keyboard leaves the link. The
+	 * device then remains disconnected until the controller is reset. Re-arm
+	 * the kernel entry for the affected Pebble K380s instead of resetting the
+	 * whole adapter.
+	 */
+	if (device->auto_connect && bdaddr_type != BDADDR_BREDR &&
+			btd_device_get_vendor(device) == 0x046d &&
+			btd_device_get_product(device) == 0xb377) {
+		info("PEBBLE_TRACE rearming kernel auto-connect after reason=0x%02x",
+								reason);
+		adapter_auto_connect_remove(device->adapter, device);
+		adapter_auto_connect_add(device->adapter, device);
+	}
+
 	g_dbus_emit_property_changed(dbus_conn, device->path,
 						DEVICE_INTERFACE, "Connected");
 

--- a/src/main.c
+++ b/src/main.c
@@ -1410,6 +1410,16 @@ static void init_defaults(void)
 	btd_opts.defaults.le.addr_resolution = 0x01;
 	btd_opts.defaults.le.enable_advmon_interleave_scan = 0xFF;
 
+	/* This fork targets a mains-powered desktop with a multi-host Pebble
+	 * keyboard. Use a continuous 10 ms scan window while auto-connecting and
+	 * while establishing the LE link, minimizing the delay after the adapter
+	 * is reset. Values are in Bluetooth units of 0.625 ms (0x0010 = 10 ms).
+	 */
+	btd_opts.defaults.le.scan_interval_autoconnect = 0x0010;
+	btd_opts.defaults.le.scan_win_autoconnect = 0x0010;
+	btd_opts.defaults.le.scan_interval_connect = 0x0010;
+	btd_opts.defaults.le.scan_win_connect = 0x0010;
+
 	if (sscanf(VERSION, "%hhu.%hhu", &major, &minor) != 2)
 		return;
 

--- a/tools/capture-pebble-trace.sh
+++ b/tools/capture-pebble-trace.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+output=${1:-"$HOME/Documents/bluez-pebble/pebble-trace.log"}
+
+echo "Capturando PEBBLE_TRACE em $output"
+echo "Use Ctrl+C para encerrar."
+sudo journalctl -u bluetooth.service -f -o short-precise \
+	| grep --line-buffered 'PEBBLE_TRACE' \
+	| tee -a "$output"

--- a/tools/install-pebble-trace.sh
+++ b/tools/install-pebble-trace.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+binary="$repo/src/bluetoothd"
+
+if [ ! -x "$binary" ]; then
+	echo "Execute make antes de instalar." >&2
+	exit 1
+fi
+
+sudo -v
+sudo install -m 0755 "$binary" /usr/local/libexec/bluetooth/bluetoothd-5.87
+sudo systemctl restart bluetooth.service
+sudo systemctl --no-pager --full status bluetooth.service | sed -n '1,14p'
+
+echo "Instrumentação Pebble instalada."


### PR DESCRIPTION
## Summary

- add targeted HoG/GATT tracing for Logitech Pebble K380s (`046d:b377`)
- re-arm the kernel LE auto-connect entry after disconnect
- reset the affected `0a12:0001` USB adapter automatically when the keyboard leaves its Linux Easy-Switch channel
- reduce reset scheduling latency to 1 ms
- use a continuous 10 ms LE auto-connect/connection scan window on this desktop-focused fork
- include capture and reversible installation helpers

## Observed failure

BlueZ cleanly detached HoG when the keyboard changed channels, but did not attach again after returning. A USB reset immediately restored attach, CCC subscriptions, and HID input reports.

## Validation

Built against Debian 13 libraries and tested with BlueZ 5.87 on the affected host. Automatic recovery works without manually removing the dongle.